### PR TITLE
ring add performance + tests + bench

### DIFF
--- a/contrib/hash_ring.c
+++ b/contrib/hash_ring.c
@@ -270,7 +270,7 @@ int hash_ring_add_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen, uint3
 
     // Sort the items
     if(doSort == 1) {
-        quicksort((void**)ring->items, ring->numItems, item_sort);
+        hash_ring_sort(ring);
     }
 
     return HASH_RING_OK;
@@ -311,7 +311,7 @@ int hash_ring_remove_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen) {
                 
                 // By re-sorting, all the NULLs will be at the end of the array
                 // Then the numItems is reset and that memory is no longer used
-                quicksort((void**)ring->items, ring->numItems, item_sort);
+                hash_ring_sort(ring);
                 ring->numItems -= itemsRemoved;
                 
                 free(node);

--- a/contrib/hash_ring.c
+++ b/contrib/hash_ring.c
@@ -37,6 +37,7 @@ hash_ring_t *hash_ring_create(HASH_FUNCTION hash_fn) {
     
     ring->nodes = NULL;
     ring->items = NULL;
+    ring->itemsSize = 0;
     ring->numNodes = 0;
     ring->numItems = 0;
     ring->hash_fn = hash_fn;
@@ -65,6 +66,7 @@ void hash_ring_free(hash_ring_t *ring) {
         free(ring->items[x]);
     }
     if(ring->items != NULL) free(ring->items);
+    ring->itemsSize = 0;
     
     free(ring);
 }
@@ -168,11 +170,10 @@ int hash_ring_add_items(hash_ring_t *ring, hash_ring_node_t *node) {
     uint64_t keyInt;
 
     // Resize the items array
-    void *resized = realloc(ring->items, (sizeof(hash_ring_item_t*) * (ring->numItems + node->numReplicas)));
-    if(resized == NULL) {
+    size_t targetItemsSize = sizeof(hash_ring_item_t*) * (ring->numItems + node->numReplicas);
+    if(hash_ring_ensure_items_size(ring, targetItemsSize) == HASH_RING_ERR) {
         return HASH_RING_ERR;
     }
-    ring->items = (hash_ring_item_t**)resized;
 
     uint8_t *data = (uint8_t*)malloc(sizeof(concat_buf) + node->nameLen);
     if(data == NULL) {
@@ -226,7 +227,7 @@ static int item_sort(void *a, void *b) {
     }
 }
 
-int hash_ring_add_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen, uint32_t numReplicas) {
+int hash_ring_add_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen, uint32_t numReplicas, int doSort) {
     // numReplicas must be greater than or equal to 1
     if(numReplicas <= 0) return HASH_RING_ERR;
     if(ring == NULL) return HASH_RING_ERR;
@@ -268,7 +269,9 @@ int hash_ring_add_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen, uint3
     }
 
     // Sort the items
-    quicksort((void**)ring->items, ring->numItems, item_sort);
+    if(doSort == 1) {
+        quicksort((void**)ring->items, ring->numItems, item_sort);
+    }
 
     return HASH_RING_OK;
 }
@@ -455,4 +458,28 @@ int hash_ring_set_mode(hash_ring_t *ring, HASH_MODE mode) {
         /* Invalid mode */
         return HASH_RING_ERR;
     }
+}
+
+int hash_ring_ensure_items_size(hash_ring_t *ring, size_t targetItemsSize) {
+    if(targetItemsSize <= ring->itemsSize) {
+        return HASH_RING_OK;
+    }
+
+    void *resized = realloc(ring->items, targetItemsSize);
+    if(resized == NULL) {
+        return HASH_RING_ERR;
+    }
+
+    ring->items = (hash_ring_item_t**)resized;
+    ring->itemsSize = targetItemsSize;
+
+    return HASH_RING_OK;
+}
+
+int hash_ring_sort(hash_ring_t *ring) {
+    if(ring->items != NULL) {
+        quicksort((void**)ring->items, ring->numItems, item_sort);
+    }
+
+    return HASH_RING_OK;
 }

--- a/contrib/hash_ring.h
+++ b/contrib/hash_ring.h
@@ -89,6 +89,11 @@ typedef struct hash_ring_t {
      * This array is sorted ascending
      */
     hash_ring_item_t **items;
+
+    /**
+     * How big the items array has allocated
+     */
+    size_t itemsSize;
     
     /* The number of items in the ring */
     uint32_t numItems;
@@ -128,9 +133,10 @@ void hash_ring_free(hash_ring_t *ring);
  * of how many times it is added.
  *
  * @param[in] numReplicas The number of replicas this node shall contain.
+ * @param[in] doSort Whether we should sort the internal items array. If set to 0, hash_ring_sort must be called.
  * @returns HASH_RING_OK if the node was added, HASH_RING_ERR if an error occurred.
  */
-int hash_ring_add_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen, uint32_t numReplicas);
+int hash_ring_add_node(hash_ring_t *ring, uint8_t *name, uint32_t nameLen, uint32_t numReplicas, int doSort);
 
 
 /**
@@ -188,5 +194,26 @@ void hash_ring_print(hash_ring_t *ring);
  * @returns HASH_RING_OK if the mode was set.
  */
 int hash_ring_set_mode(hash_ring_t *ring, HASH_MODE mode);
+
+/**
+ * Resizes the internal items array. Use this if you know the total number of replicas you plan to add ahead
+ * of time, to avoid excessive re-allocations.
+ *
+ * @param ring The ring to resize the items array of.
+ * @param targetItemsSize How big you want the items array to be resized to.
+ *
+ * @returns HASH_RING_OK if the resize was successful.
+ */
+int hash_ring_ensure_items_size(hash_ring_t *ring, size_t targetItemsSize);
+
+
+/**
+ * Sorts the hash items array of the hash ring. You must call this after calling hash_ring_add_node with do_sort == 0.
+ *
+ * @param ring The ring to sort the internal items array of.
+ *
+ * @returns HASH_RING_OK if the sort was successful.
+ */
+int hash_ring_sort(hash_ring_t* ring);
 
 #endif

--- a/hash_ring/__init__.py
+++ b/hash_ring/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from .hash_ring import HashRing, HASH_FUNCTION_SHA1, HASH_FUNCTION_MD5
+from .hash_ring import HashRing, HashRingNode, HASH_FUNCTION_SHA1, HASH_FUNCTION_MD5
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
-__all__ = ['HashRing', 'HASH_FUNCTION_SHA1', 'HASH_FUNCTION_MD5']
+__all__ = ['HashRing', 'HashRingNode', 'HASH_FUNCTION_SHA1', 'HASH_FUNCTION_MD5']

--- a/hash_ring/hash_ring.c
+++ b/hash_ring/hash_ring.c
@@ -492,9 +492,9 @@ static const char *__pyx_f[] = {
 /*--- Type declarations ---*/
 struct __pyx_obj_9hash_ring_9hash_ring_HashRing;
 
-/* "hash_ring/hash_ring.pyx":31
+/* "hash_ring/hash_ring.pyx":35
+ * HASH_FUNCTION_SHA1 = _HASH_FUNCTION_SHA1
  * HASH_FUNCTION_MD5 = _HASH_FUNCTION_MD5
- * 
  * cdef class HashRing:             # <<<<<<<<<<<<<<
  *     cdef hash_ring_t *_ring
  *     cdef unsigned int _default_num_replicas
@@ -608,6 +608,39 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_Call(PyObject *func, PyObject *arg
 #define __Pyx_PyObject_Call(func, arg, kw) PyObject_Call(func, arg, kw)
 #endif
 
+/* PyObjectCallMethO.proto */
+#if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallMethO(PyObject *func, PyObject *arg);
+#endif
+
+/* PyObjectCallOneArg.proto */
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObject *arg);
+
+/* PyObjectCallNoArg.proto */
+#if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func);
+#else
+#define __Pyx_PyObject_CallNoArg(func) __Pyx_PyObject_Call(func, __pyx_empty_tuple, NULL)
+#endif
+
+/* PyObjectSetAttrStr.proto */
+#if CYTHON_COMPILING_IN_CPYTHON
+#define __Pyx_PyObject_DelAttrStr(o,n) __Pyx_PyObject_SetAttrStr(o,n,NULL)
+static CYTHON_INLINE int __Pyx_PyObject_SetAttrStr(PyObject* obj, PyObject* attr_name, PyObject* value) {
+    PyTypeObject* tp = Py_TYPE(obj);
+    if (likely(tp->tp_setattro))
+        return tp->tp_setattro(obj, attr_name, value);
+#if PY_MAJOR_VERSION < 3
+    if (likely(tp->tp_setattr))
+        return tp->tp_setattr(obj, PyString_AS_STRING(attr_name), value);
+#endif
+    return PyObject_SetAttr(obj, attr_name, value);
+}
+#else
+#define __Pyx_PyObject_DelAttrStr(o,n)   PyObject_DelAttr(o,n)
+#define __Pyx_PyObject_SetAttrStr(o,n,v) PyObject_SetAttr(o,n,v)
+#endif
+
 /* ListCompAppend.proto */
 #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x) {
@@ -679,6 +712,72 @@ static CYTHON_INLINE void __Pyx__ExceptionReset(PyThreadState *tstate, PyObject 
 /* GetModuleGlobalName.proto */
 static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name);
 
+/* FetchCommonType.proto */
+static PyTypeObject* __Pyx_FetchCommonType(PyTypeObject* type);
+
+/* CythonFunction.proto */
+#define __Pyx_CyFunction_USED 1
+#include <structmember.h>
+#define __Pyx_CYFUNCTION_STATICMETHOD  0x01
+#define __Pyx_CYFUNCTION_CLASSMETHOD   0x02
+#define __Pyx_CYFUNCTION_CCLASS        0x04
+#define __Pyx_CyFunction_GetClosure(f)\
+    (((__pyx_CyFunctionObject *) (f))->func_closure)
+#define __Pyx_CyFunction_GetClassObj(f)\
+    (((__pyx_CyFunctionObject *) (f))->func_classobj)
+#define __Pyx_CyFunction_Defaults(type, f)\
+    ((type *)(((__pyx_CyFunctionObject *) (f))->defaults))
+#define __Pyx_CyFunction_SetDefaultsGetter(f, g)\
+    ((__pyx_CyFunctionObject *) (f))->defaults_getter = (g)
+typedef struct {
+    PyCFunctionObject func;
+#if PY_VERSION_HEX < 0x030500A0
+    PyObject *func_weakreflist;
+#endif
+    PyObject *func_dict;
+    PyObject *func_name;
+    PyObject *func_qualname;
+    PyObject *func_doc;
+    PyObject *func_globals;
+    PyObject *func_code;
+    PyObject *func_closure;
+    PyObject *func_classobj;
+    void *defaults;
+    int defaults_pyobjects;
+    int flags;
+    PyObject *defaults_tuple;
+    PyObject *defaults_kwdict;
+    PyObject *(*defaults_getter)(PyObject *);
+    PyObject *func_annotations;
+} __pyx_CyFunctionObject;
+static PyTypeObject *__pyx_CyFunctionType = 0;
+#define __Pyx_CyFunction_NewEx(ml, flags, qualname, self, module, globals, code)\
+    __Pyx_CyFunction_New(__pyx_CyFunctionType, ml, flags, qualname, self, module, globals, code)
+static PyObject *__Pyx_CyFunction_New(PyTypeObject *, PyMethodDef *ml,
+                                      int flags, PyObject* qualname,
+                                      PyObject *self,
+                                      PyObject *module, PyObject *globals,
+                                      PyObject* code);
+static CYTHON_INLINE void *__Pyx_CyFunction_InitDefaults(PyObject *m,
+                                                         size_t size,
+                                                         int pyobjects);
+static CYTHON_INLINE void __Pyx_CyFunction_SetDefaultsTuple(PyObject *m,
+                                                            PyObject *tuple);
+static CYTHON_INLINE void __Pyx_CyFunction_SetDefaultsKwDict(PyObject *m,
+                                                             PyObject *dict);
+static CYTHON_INLINE void __Pyx_CyFunction_SetAnnotationsDict(PyObject *m,
+                                                              PyObject *dict);
+static int __pyx_CyFunction_init(void);
+
+/* CalculateMetaclass.proto */
+static PyObject *__Pyx_CalculateMetaclass(PyTypeObject *metaclass, PyObject *bases);
+
+/* Py3ClassCreate.proto */
+static PyObject *__Pyx_Py3MetaclassPrepare(PyObject *metaclass, PyObject *bases, PyObject *name, PyObject *qualname,
+                                           PyObject *mkw, PyObject *modname, PyObject *doc);
+static PyObject *__Pyx_Py3ClassCreate(PyObject *metaclass, PyObject *name, PyObject *bases, PyObject *dict,
+                                      PyObject *mkw, int calculate_metaclass, int allow_py2_metaclass);
+
 /* CodeObjectCache.proto */
 typedef struct {
     PyCodeObject* code_object;
@@ -740,41 +839,72 @@ int __pyx_module_is_main_hash_ring__hash_ring = 0;
 
 /* Implementation of 'hash_ring.hash_ring' */
 static PyObject *__pyx_builtin_MemoryError;
+static const char __pyx_k_doc[] = "__doc__";
 static const char __pyx_k_key[] = "key";
 static const char __pyx_k_num[] = "num";
+static const char __pyx_k_init[] = "__init__";
 static const char __pyx_k_main[] = "__main__";
 static const char __pyx_k_name[] = "name";
+static const char __pyx_k_self[] = "self";
 static const char __pyx_k_test[] = "__test__";
+static const char __pyx_k_module[] = "__module__";
 static const char __pyx_k_hash_fn[] = "hash_fn";
+static const char __pyx_k_prepare[] = "__prepare__";
+static const char __pyx_k_qualname[] = "__qualname__";
+static const char __pyx_k_metaclass[] = "__metaclass__";
 static const char __pyx_k_MemoryError[] = "MemoryError";
+static const char __pyx_k_HashRingNode[] = "HashRingNode";
 static const char __pyx_k_num_replicas[] = "num_replicas";
+static const char __pyx_k_get_num_items[] = "get_num_items";
 static const char __pyx_k_HASH_FUNCTION_MD5[] = "HASH_FUNCTION_MD5";
 static const char __pyx_k_HASH_FUNCTION_SHA1[] = "HASH_FUNCTION_SHA1";
+static const char __pyx_k_HashRingNode___init[] = "HashRingNode.__init__";
+static const char __pyx_k_hash_ring_hash_ring[] = "hash_ring.hash_ring";
 static const char __pyx_k_default_num_replicas[] = "default_num_replicas";
+static const char __pyx_k_Users_jake_PycharmProjects_hash[] = "/Users/jake/PycharmProjects/hash_ring/hash_ring/hash_ring.pyx";
 static PyObject *__pyx_n_s_HASH_FUNCTION_MD5;
 static PyObject *__pyx_n_s_HASH_FUNCTION_SHA1;
+static PyObject *__pyx_n_s_HashRingNode;
+static PyObject *__pyx_n_s_HashRingNode___init;
 static PyObject *__pyx_n_s_MemoryError;
+static PyObject *__pyx_kp_s_Users_jake_PycharmProjects_hash;
 static PyObject *__pyx_n_s_default_num_replicas;
+static PyObject *__pyx_n_s_doc;
+static PyObject *__pyx_n_s_get_num_items;
 static PyObject *__pyx_n_s_hash_fn;
+static PyObject *__pyx_n_s_hash_ring_hash_ring;
+static PyObject *__pyx_n_s_init;
 static PyObject *__pyx_n_s_key;
 static PyObject *__pyx_n_s_main;
+static PyObject *__pyx_n_s_metaclass;
+static PyObject *__pyx_n_s_module;
 static PyObject *__pyx_n_s_name;
 static PyObject *__pyx_n_s_num;
 static PyObject *__pyx_n_s_num_replicas;
+static PyObject *__pyx_n_s_prepare;
+static PyObject *__pyx_n_s_qualname;
+static PyObject *__pyx_n_s_self;
 static PyObject *__pyx_n_s_test;
 static int __pyx_pf_9hash_ring_9hash_ring_8HashRing___cinit__(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_default_num_replicas, PyObject *__pyx_v_hash_fn); /* proto */
 static void __pyx_pf_9hash_ring_9hash_ring_8HashRing_2__dealloc__(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self); /* proto */
 static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_4add_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_name, PyObject *__pyx_v_num_replicas); /* proto */
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_name); /* proto */
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8print_ring(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key); /* proto */
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_num); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6add_nodes(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_nodes); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8remove_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_name); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10print_ring(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_14find_nodes(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_num); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_16get_num_items(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_18get_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_node_name); /* proto */
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_12HashRingNode___init__(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_name, PyObject *__pyx_v_num_replicas); /* proto */
 static PyObject *__pyx_tp_new_9hash_ring_9hash_ring_HashRing(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
+static PyObject *__pyx_int_0;
 static PyObject *__pyx_int_1;
 static PyObject *__pyx_int_128;
 static PyObject *__pyx_k_;
+static PyObject *__pyx_tuple__2;
+static PyObject *__pyx_codeobj__3;
 
-/* "hash_ring/hash_ring.pyx":35
+/* "hash_ring/hash_ring.pyx":39
  *     cdef unsigned int _default_num_replicas
  * 
  *     def __cinit__(self, default_num_replicas=128, hash_fn=HASH_FUNCTION_MD5):             # <<<<<<<<<<<<<<
@@ -818,7 +948,7 @@ static int __pyx_pw_9hash_ring_9hash_ring_8HashRing_1__cinit__(PyObject *__pyx_v
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 35, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 39, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -833,7 +963,7 @@ static int __pyx_pw_9hash_ring_9hash_ring_8HashRing_1__cinit__(PyObject *__pyx_v
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 0, 0, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 35, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 0, 0, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 39, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("hash_ring.hash_ring.HashRing.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -853,27 +983,27 @@ static int __pyx_pf_9hash_ring_9hash_ring_8HashRing___cinit__(struct __pyx_obj_9
   unsigned int __pyx_t_2;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "hash_ring/hash_ring.pyx":36
+  /* "hash_ring/hash_ring.pyx":40
  * 
  *     def __cinit__(self, default_num_replicas=128, hash_fn=HASH_FUNCTION_MD5):
  *         self._ring = hash_ring_create(hash_fn)             # <<<<<<<<<<<<<<
  *         self._default_num_replicas = default_num_replicas
  * 
  */
-  __pyx_t_1 = __Pyx_PyInt_As_HASH_FUNCTION(__pyx_v_hash_fn); if (unlikely((__pyx_t_1 == (HASH_FUNCTION)-1) && PyErr_Occurred())) __PYX_ERR(0, 36, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_As_HASH_FUNCTION(__pyx_v_hash_fn); if (unlikely((__pyx_t_1 == (HASH_FUNCTION)-1) && PyErr_Occurred())) __PYX_ERR(0, 40, __pyx_L1_error)
   __pyx_v_self->_ring = hash_ring_create(__pyx_t_1);
 
-  /* "hash_ring/hash_ring.pyx":37
+  /* "hash_ring/hash_ring.pyx":41
  *     def __cinit__(self, default_num_replicas=128, hash_fn=HASH_FUNCTION_MD5):
  *         self._ring = hash_ring_create(hash_fn)
  *         self._default_num_replicas = default_num_replicas             # <<<<<<<<<<<<<<
  * 
  *     def __dealloc__(self):
  */
-  __pyx_t_2 = __Pyx_PyInt_As_unsigned_int(__pyx_v_default_num_replicas); if (unlikely((__pyx_t_2 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 37, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_As_unsigned_int(__pyx_v_default_num_replicas); if (unlikely((__pyx_t_2 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 41, __pyx_L1_error)
   __pyx_v_self->_default_num_replicas = __pyx_t_2;
 
-  /* "hash_ring/hash_ring.pyx":35
+  /* "hash_ring/hash_ring.pyx":39
  *     cdef unsigned int _default_num_replicas
  * 
  *     def __cinit__(self, default_num_replicas=128, hash_fn=HASH_FUNCTION_MD5):             # <<<<<<<<<<<<<<
@@ -892,7 +1022,7 @@ static int __pyx_pf_9hash_ring_9hash_ring_8HashRing___cinit__(struct __pyx_obj_9
   return __pyx_r;
 }
 
-/* "hash_ring/hash_ring.pyx":39
+/* "hash_ring/hash_ring.pyx":43
  *         self._default_num_replicas = default_num_replicas
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -915,7 +1045,7 @@ static void __pyx_pf_9hash_ring_9hash_ring_8HashRing_2__dealloc__(struct __pyx_o
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__dealloc__", 0);
 
-  /* "hash_ring/hash_ring.pyx":40
+  /* "hash_ring/hash_ring.pyx":44
  * 
  *     def __dealloc__(self):
  *         hash_ring_free(self._ring)             # <<<<<<<<<<<<<<
@@ -924,7 +1054,7 @@ static void __pyx_pf_9hash_ring_9hash_ring_8HashRing_2__dealloc__(struct __pyx_o
  */
   hash_ring_free(__pyx_v_self->_ring);
 
-  /* "hash_ring/hash_ring.pyx":39
+  /* "hash_ring/hash_ring.pyx":43
  *         self._default_num_replicas = default_num_replicas
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -936,7 +1066,7 @@ static void __pyx_pf_9hash_ring_9hash_ring_8HashRing_2__dealloc__(struct __pyx_o
   __Pyx_RefNannyFinishContext();
 }
 
-/* "hash_ring/hash_ring.pyx":42
+/* "hash_ring/hash_ring.pyx":46
  *         hash_ring_free(self._ring)
  * 
  *     def add_node(self, name, num_replicas=None):             # <<<<<<<<<<<<<<
@@ -977,7 +1107,7 @@ static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_5add_node(PyObject *__
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "add_node") < 0)) __PYX_ERR(0, 42, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "add_node") < 0)) __PYX_ERR(0, 46, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -992,7 +1122,7 @@ static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_5add_node(PyObject *__
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("add_node", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 42, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("add_node", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 46, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("hash_ring.hash_ring.HashRing.add_node", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -1017,7 +1147,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_4add_node(struct __pyx
   __Pyx_RefNannySetupContext("add_node", 0);
   __Pyx_INCREF(__pyx_v_num_replicas);
 
-  /* "hash_ring/hash_ring.pyx":43
+  /* "hash_ring/hash_ring.pyx":47
  * 
  *     def add_node(self, name, num_replicas=None):
  *         if num_replicas is None:             # <<<<<<<<<<<<<<
@@ -1028,19 +1158,19 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_4add_node(struct __pyx
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "hash_ring/hash_ring.pyx":44
+    /* "hash_ring/hash_ring.pyx":48
  *     def add_node(self, name, num_replicas=None):
  *         if num_replicas is None:
  *             num_replicas = self._default_num_replicas             # <<<<<<<<<<<<<<
  * 
- *         return hash_ring_add_node(self._ring, name, len(name), num_replicas) == HASH_RING_OK
+ *         return hash_ring_add_node(self._ring, name, len(name), num_replicas, 1) == HASH_RING_OK
  */
-    __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_self->_default_num_replicas); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 44, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_self->_default_num_replicas); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 48, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF_SET(__pyx_v_num_replicas, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "hash_ring/hash_ring.pyx":43
+    /* "hash_ring/hash_ring.pyx":47
  * 
  *     def add_node(self, name, num_replicas=None):
  *         if num_replicas is None:             # <<<<<<<<<<<<<<
@@ -1049,24 +1179,24 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_4add_node(struct __pyx
  */
   }
 
-  /* "hash_ring/hash_ring.pyx":46
+  /* "hash_ring/hash_ring.pyx":50
  *             num_replicas = self._default_num_replicas
  * 
- *         return hash_ring_add_node(self._ring, name, len(name), num_replicas) == HASH_RING_OK             # <<<<<<<<<<<<<<
+ *         return hash_ring_add_node(self._ring, name, len(name), num_replicas, 1) == HASH_RING_OK             # <<<<<<<<<<<<<<
  * 
- *     def remove_node(self, name):
+ *     def add_nodes(self, nodes):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_PyObject_AsUString(__pyx_v_name); if (unlikely((!__pyx_t_4) && PyErr_Occurred())) __PYX_ERR(0, 46, __pyx_L1_error)
-  __pyx_t_5 = PyObject_Length(__pyx_v_name); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 46, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_unsigned_int(__pyx_v_num_replicas); if (unlikely((__pyx_t_6 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 46, __pyx_L1_error)
-  __pyx_t_3 = __Pyx_PyBool_FromLong((hash_ring_add_node(__pyx_v_self->_ring, __pyx_t_4, __pyx_t_5, __pyx_t_6) == HASH_RING_OK)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 46, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_AsUString(__pyx_v_name); if (unlikely((!__pyx_t_4) && PyErr_Occurred())) __PYX_ERR(0, 50, __pyx_L1_error)
+  __pyx_t_5 = PyObject_Length(__pyx_v_name); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 50, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_unsigned_int(__pyx_v_num_replicas); if (unlikely((__pyx_t_6 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 50, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyBool_FromLong((hash_ring_add_node(__pyx_v_self->_ring, __pyx_t_4, __pyx_t_5, __pyx_t_6, 1) == HASH_RING_OK)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 50, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_r = __pyx_t_3;
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "hash_ring/hash_ring.pyx":42
+  /* "hash_ring/hash_ring.pyx":46
  *         hash_ring_free(self._ring)
  * 
  *     def add_node(self, name, num_replicas=None):             # <<<<<<<<<<<<<<
@@ -1086,8 +1216,426 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_4add_node(struct __pyx
   return __pyx_r;
 }
 
-/* "hash_ring/hash_ring.pyx":48
- *         return hash_ring_add_node(self._ring, name, len(name), num_replicas) == HASH_RING_OK
+/* "hash_ring/hash_ring.pyx":52
+ *         return hash_ring_add_node(self._ring, name, len(name), num_replicas, 1) == HASH_RING_OK
+ * 
+ *     def add_nodes(self, nodes):             # <<<<<<<<<<<<<<
+ *         if not nodes:
+ *             return
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_7add_nodes(PyObject *__pyx_v_self, PyObject *__pyx_v_nodes); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_7add_nodes(PyObject *__pyx_v_self, PyObject *__pyx_v_nodes) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("add_nodes (wrapper)", 0);
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_6add_nodes(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), ((PyObject *)__pyx_v_nodes));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6add_nodes(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_nodes) {
+  size_t __pyx_v_items_size_target;
+  PyObject *__pyx_v_node = NULL;
+  PyObject *__pyx_r = NULL;
+  __Pyx_RefNannyDeclarations
+  int __pyx_t_1;
+  int __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  PyObject *__pyx_t_5 = NULL;
+  Py_ssize_t __pyx_t_6;
+  PyObject *(*__pyx_t_7)(PyObject *);
+  PyObject *__pyx_t_8 = NULL;
+  size_t __pyx_t_9;
+  unsigned char *__pyx_t_10;
+  Py_ssize_t __pyx_t_11;
+  unsigned int __pyx_t_12;
+  __Pyx_RefNannySetupContext("add_nodes", 0);
+
+  /* "hash_ring/hash_ring.pyx":53
+ * 
+ *     def add_nodes(self, nodes):
+ *         if not nodes:             # <<<<<<<<<<<<<<
+ *             return
+ * 
+ */
+  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_v_nodes); if (unlikely(__pyx_t_1 < 0)) __PYX_ERR(0, 53, __pyx_L1_error)
+  __pyx_t_2 = ((!__pyx_t_1) != 0);
+  if (__pyx_t_2) {
+
+    /* "hash_ring/hash_ring.pyx":54
+ *     def add_nodes(self, nodes):
+ *         if not nodes:
+ *             return             # <<<<<<<<<<<<<<
+ * 
+ *         # Cannot add nodes if the ring already has nodes.
+ */
+    __Pyx_XDECREF(__pyx_r);
+    __pyx_r = Py_None; __Pyx_INCREF(Py_None);
+    goto __pyx_L0;
+
+    /* "hash_ring/hash_ring.pyx":53
+ * 
+ *     def add_nodes(self, nodes):
+ *         if not nodes:             # <<<<<<<<<<<<<<
+ *             return
+ * 
+ */
+  }
+
+  /* "hash_ring/hash_ring.pyx":57
+ * 
+ *         # Cannot add nodes if the ring already has nodes.
+ *         if self.get_num_items() > 0:             # <<<<<<<<<<<<<<
+ *             return False
+ * 
+ */
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_get_num_items); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 57, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __pyx_t_5 = NULL;
+  if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
+    __pyx_t_5 = PyMethod_GET_SELF(__pyx_t_4);
+    if (likely(__pyx_t_5)) {
+      PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_4);
+      __Pyx_INCREF(__pyx_t_5);
+      __Pyx_INCREF(function);
+      __Pyx_DECREF_SET(__pyx_t_4, function);
+    }
+  }
+  if (__pyx_t_5) {
+    __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 57, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  } else {
+    __pyx_t_3 = __Pyx_PyObject_CallNoArg(__pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 57, __pyx_L1_error)
+  }
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+  __pyx_t_4 = PyObject_RichCompare(__pyx_t_3, __pyx_int_0, Py_GT); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 57, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 57, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+  if (__pyx_t_2) {
+
+    /* "hash_ring/hash_ring.pyx":58
+ *         # Cannot add nodes if the ring already has nodes.
+ *         if self.get_num_items() > 0:
+ *             return False             # <<<<<<<<<<<<<<
+ * 
+ *         cdef size_t items_size_target = 0
+ */
+    __Pyx_XDECREF(__pyx_r);
+    __Pyx_INCREF(Py_False);
+    __pyx_r = Py_False;
+    goto __pyx_L0;
+
+    /* "hash_ring/hash_ring.pyx":57
+ * 
+ *         # Cannot add nodes if the ring already has nodes.
+ *         if self.get_num_items() > 0:             # <<<<<<<<<<<<<<
+ *             return False
+ * 
+ */
+  }
+
+  /* "hash_ring/hash_ring.pyx":60
+ *             return False
+ * 
+ *         cdef size_t items_size_target = 0             # <<<<<<<<<<<<<<
+ *         for node in nodes:
+ *             if node.num_replicas is None:
+ */
+  __pyx_v_items_size_target = 0;
+
+  /* "hash_ring/hash_ring.pyx":61
+ * 
+ *         cdef size_t items_size_target = 0
+ *         for node in nodes:             # <<<<<<<<<<<<<<
+ *             if node.num_replicas is None:
+ *                 node.num_replicas = self._default_num_replicas
+ */
+  if (likely(PyList_CheckExact(__pyx_v_nodes)) || PyTuple_CheckExact(__pyx_v_nodes)) {
+    __pyx_t_4 = __pyx_v_nodes; __Pyx_INCREF(__pyx_t_4); __pyx_t_6 = 0;
+    __pyx_t_7 = NULL;
+  } else {
+    __pyx_t_6 = -1; __pyx_t_4 = PyObject_GetIter(__pyx_v_nodes); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 61, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_4);
+    __pyx_t_7 = Py_TYPE(__pyx_t_4)->tp_iternext; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 61, __pyx_L1_error)
+  }
+  for (;;) {
+    if (likely(!__pyx_t_7)) {
+      if (likely(PyList_CheckExact(__pyx_t_4))) {
+        if (__pyx_t_6 >= PyList_GET_SIZE(__pyx_t_4)) break;
+        #if CYTHON_COMPILING_IN_CPYTHON
+        __pyx_t_3 = PyList_GET_ITEM(__pyx_t_4, __pyx_t_6); __Pyx_INCREF(__pyx_t_3); __pyx_t_6++; if (unlikely(0 < 0)) __PYX_ERR(0, 61, __pyx_L1_error)
+        #else
+        __pyx_t_3 = PySequence_ITEM(__pyx_t_4, __pyx_t_6); __pyx_t_6++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 61, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        #endif
+      } else {
+        if (__pyx_t_6 >= PyTuple_GET_SIZE(__pyx_t_4)) break;
+        #if CYTHON_COMPILING_IN_CPYTHON
+        __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_4, __pyx_t_6); __Pyx_INCREF(__pyx_t_3); __pyx_t_6++; if (unlikely(0 < 0)) __PYX_ERR(0, 61, __pyx_L1_error)
+        #else
+        __pyx_t_3 = PySequence_ITEM(__pyx_t_4, __pyx_t_6); __pyx_t_6++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 61, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        #endif
+      }
+    } else {
+      __pyx_t_3 = __pyx_t_7(__pyx_t_4);
+      if (unlikely(!__pyx_t_3)) {
+        PyObject* exc_type = PyErr_Occurred();
+        if (exc_type) {
+          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+          else __PYX_ERR(0, 61, __pyx_L1_error)
+        }
+        break;
+      }
+      __Pyx_GOTREF(__pyx_t_3);
+    }
+    __Pyx_XDECREF_SET(__pyx_v_node, __pyx_t_3);
+    __pyx_t_3 = 0;
+
+    /* "hash_ring/hash_ring.pyx":62
+ *         cdef size_t items_size_target = 0
+ *         for node in nodes:
+ *             if node.num_replicas is None:             # <<<<<<<<<<<<<<
+ *                 node.num_replicas = self._default_num_replicas
+ * 
+ */
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_node, __pyx_n_s_num_replicas); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 62, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_t_2 = (__pyx_t_3 == Py_None);
+    __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+    __pyx_t_1 = (__pyx_t_2 != 0);
+    if (__pyx_t_1) {
+
+      /* "hash_ring/hash_ring.pyx":63
+ *         for node in nodes:
+ *             if node.num_replicas is None:
+ *                 node.num_replicas = self._default_num_replicas             # <<<<<<<<<<<<<<
+ * 
+ *             items_size_target += node.num_replicas
+ */
+      __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_self->_default_num_replicas); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 63, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_3);
+      if (__Pyx_PyObject_SetAttrStr(__pyx_v_node, __pyx_n_s_num_replicas, __pyx_t_3) < 0) __PYX_ERR(0, 63, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+
+      /* "hash_ring/hash_ring.pyx":62
+ *         cdef size_t items_size_target = 0
+ *         for node in nodes:
+ *             if node.num_replicas is None:             # <<<<<<<<<<<<<<
+ *                 node.num_replicas = self._default_num_replicas
+ * 
+ */
+    }
+
+    /* "hash_ring/hash_ring.pyx":65
+ *                 node.num_replicas = self._default_num_replicas
+ * 
+ *             items_size_target += node.num_replicas             # <<<<<<<<<<<<<<
+ * 
+ *         if hash_ring_ensure_items_size(self._ring, items_size_target) != HASH_RING_OK:
+ */
+    __pyx_t_3 = __Pyx_PyInt_FromSize_t(__pyx_v_items_size_target); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 65, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_node, __pyx_n_s_num_replicas); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 65, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_8 = PyNumber_InPlaceAdd(__pyx_t_3, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 65, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_8);
+    __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+    __pyx_t_9 = __Pyx_PyInt_As_size_t(__pyx_t_8); if (unlikely((__pyx_t_9 == (size_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 65, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
+    __pyx_v_items_size_target = __pyx_t_9;
+
+    /* "hash_ring/hash_ring.pyx":61
+ * 
+ *         cdef size_t items_size_target = 0
+ *         for node in nodes:             # <<<<<<<<<<<<<<
+ *             if node.num_replicas is None:
+ *                 node.num_replicas = self._default_num_replicas
+ */
+  }
+  __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+  /* "hash_ring/hash_ring.pyx":67
+ *             items_size_target += node.num_replicas
+ * 
+ *         if hash_ring_ensure_items_size(self._ring, items_size_target) != HASH_RING_OK:             # <<<<<<<<<<<<<<
+ *             return False
+ * 
+ */
+  __pyx_t_1 = ((hash_ring_ensure_items_size(__pyx_v_self->_ring, __pyx_v_items_size_target) != HASH_RING_OK) != 0);
+  if (__pyx_t_1) {
+
+    /* "hash_ring/hash_ring.pyx":68
+ * 
+ *         if hash_ring_ensure_items_size(self._ring, items_size_target) != HASH_RING_OK:
+ *             return False             # <<<<<<<<<<<<<<
+ * 
+ *         for node in nodes:
+ */
+    __Pyx_XDECREF(__pyx_r);
+    __Pyx_INCREF(Py_False);
+    __pyx_r = Py_False;
+    goto __pyx_L0;
+
+    /* "hash_ring/hash_ring.pyx":67
+ *             items_size_target += node.num_replicas
+ * 
+ *         if hash_ring_ensure_items_size(self._ring, items_size_target) != HASH_RING_OK:             # <<<<<<<<<<<<<<
+ *             return False
+ * 
+ */
+  }
+
+  /* "hash_ring/hash_ring.pyx":70
+ *             return False
+ * 
+ *         for node in nodes:             # <<<<<<<<<<<<<<
+ *             if hash_ring_add_node(self._ring, node.name, len(node.name), node.num_replicas, 0) != HASH_RING_OK:
+ *                 return False
+ */
+  if (likely(PyList_CheckExact(__pyx_v_nodes)) || PyTuple_CheckExact(__pyx_v_nodes)) {
+    __pyx_t_4 = __pyx_v_nodes; __Pyx_INCREF(__pyx_t_4); __pyx_t_6 = 0;
+    __pyx_t_7 = NULL;
+  } else {
+    __pyx_t_6 = -1; __pyx_t_4 = PyObject_GetIter(__pyx_v_nodes); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 70, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_4);
+    __pyx_t_7 = Py_TYPE(__pyx_t_4)->tp_iternext; if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 70, __pyx_L1_error)
+  }
+  for (;;) {
+    if (likely(!__pyx_t_7)) {
+      if (likely(PyList_CheckExact(__pyx_t_4))) {
+        if (__pyx_t_6 >= PyList_GET_SIZE(__pyx_t_4)) break;
+        #if CYTHON_COMPILING_IN_CPYTHON
+        __pyx_t_8 = PyList_GET_ITEM(__pyx_t_4, __pyx_t_6); __Pyx_INCREF(__pyx_t_8); __pyx_t_6++; if (unlikely(0 < 0)) __PYX_ERR(0, 70, __pyx_L1_error)
+        #else
+        __pyx_t_8 = PySequence_ITEM(__pyx_t_4, __pyx_t_6); __pyx_t_6++; if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 70, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_8);
+        #endif
+      } else {
+        if (__pyx_t_6 >= PyTuple_GET_SIZE(__pyx_t_4)) break;
+        #if CYTHON_COMPILING_IN_CPYTHON
+        __pyx_t_8 = PyTuple_GET_ITEM(__pyx_t_4, __pyx_t_6); __Pyx_INCREF(__pyx_t_8); __pyx_t_6++; if (unlikely(0 < 0)) __PYX_ERR(0, 70, __pyx_L1_error)
+        #else
+        __pyx_t_8 = PySequence_ITEM(__pyx_t_4, __pyx_t_6); __pyx_t_6++; if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 70, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_8);
+        #endif
+      }
+    } else {
+      __pyx_t_8 = __pyx_t_7(__pyx_t_4);
+      if (unlikely(!__pyx_t_8)) {
+        PyObject* exc_type = PyErr_Occurred();
+        if (exc_type) {
+          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+          else __PYX_ERR(0, 70, __pyx_L1_error)
+        }
+        break;
+      }
+      __Pyx_GOTREF(__pyx_t_8);
+    }
+    __Pyx_XDECREF_SET(__pyx_v_node, __pyx_t_8);
+    __pyx_t_8 = 0;
+
+    /* "hash_ring/hash_ring.pyx":71
+ * 
+ *         for node in nodes:
+ *             if hash_ring_add_node(self._ring, node.name, len(node.name), node.num_replicas, 0) != HASH_RING_OK:             # <<<<<<<<<<<<<<
+ *                 return False
+ * 
+ */
+    __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_v_node, __pyx_n_s_name); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 71, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_8);
+    __pyx_t_10 = __Pyx_PyObject_AsUString(__pyx_t_8); if (unlikely((!__pyx_t_10) && PyErr_Occurred())) __PYX_ERR(0, 71, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_node, __pyx_n_s_name); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 71, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_11 = PyObject_Length(__pyx_t_5); if (unlikely(__pyx_t_11 == -1)) __PYX_ERR(0, 71, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_node, __pyx_n_s_num_replicas); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 71, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_12 = __Pyx_PyInt_As_unsigned_int(__pyx_t_5); if (unlikely((__pyx_t_12 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 71, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+    __pyx_t_1 = ((hash_ring_add_node(__pyx_v_self->_ring, __pyx_t_10, __pyx_t_11, __pyx_t_12, 0) != HASH_RING_OK) != 0);
+    __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
+    if (__pyx_t_1) {
+
+      /* "hash_ring/hash_ring.pyx":72
+ *         for node in nodes:
+ *             if hash_ring_add_node(self._ring, node.name, len(node.name), node.num_replicas, 0) != HASH_RING_OK:
+ *                 return False             # <<<<<<<<<<<<<<
+ * 
+ *         return hash_ring_sort(self._ring) == HASH_RING_OK
+ */
+      __Pyx_XDECREF(__pyx_r);
+      __Pyx_INCREF(Py_False);
+      __pyx_r = Py_False;
+      __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+      goto __pyx_L0;
+
+      /* "hash_ring/hash_ring.pyx":71
+ * 
+ *         for node in nodes:
+ *             if hash_ring_add_node(self._ring, node.name, len(node.name), node.num_replicas, 0) != HASH_RING_OK:             # <<<<<<<<<<<<<<
+ *                 return False
+ * 
+ */
+    }
+
+    /* "hash_ring/hash_ring.pyx":70
+ *             return False
+ * 
+ *         for node in nodes:             # <<<<<<<<<<<<<<
+ *             if hash_ring_add_node(self._ring, node.name, len(node.name), node.num_replicas, 0) != HASH_RING_OK:
+ *                 return False
+ */
+  }
+  __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+  /* "hash_ring/hash_ring.pyx":74
+ *                 return False
+ * 
+ *         return hash_ring_sort(self._ring) == HASH_RING_OK             # <<<<<<<<<<<<<<
+ * 
+ *     def remove_node(self, name):
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_4 = __Pyx_PyBool_FromLong((hash_ring_sort(__pyx_v_self->_ring) == HASH_RING_OK)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 74, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "hash_ring/hash_ring.pyx":52
+ *         return hash_ring_add_node(self._ring, name, len(name), num_replicas, 1) == HASH_RING_OK
+ * 
+ *     def add_nodes(self, nodes):             # <<<<<<<<<<<<<<
+ *         if not nodes:
+ *             return
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_XDECREF(__pyx_t_5);
+  __Pyx_XDECREF(__pyx_t_8);
+  __Pyx_AddTraceback("hash_ring.hash_ring.HashRing.add_nodes", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XDECREF(__pyx_v_node);
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "hash_ring/hash_ring.pyx":76
+ *         return hash_ring_sort(self._ring) == HASH_RING_OK
  * 
  *     def remove_node(self, name):             # <<<<<<<<<<<<<<
  *         return hash_ring_remove_node(self._ring, name, len(name)) == HASH_RING_OK
@@ -1095,19 +1643,19 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_4add_node(struct __pyx
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_7remove_node(PyObject *__pyx_v_self, PyObject *__pyx_v_name); /*proto*/
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_7remove_node(PyObject *__pyx_v_self, PyObject *__pyx_v_name) {
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_9remove_node(PyObject *__pyx_v_self, PyObject *__pyx_v_name); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_9remove_node(PyObject *__pyx_v_self, PyObject *__pyx_v_name) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("remove_node (wrapper)", 0);
-  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), ((PyObject *)__pyx_v_name));
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_8remove_node(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), ((PyObject *)__pyx_v_name));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_name) {
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8remove_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_name) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   unsigned char *__pyx_t_1;
@@ -1115,7 +1663,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(struct __
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("remove_node", 0);
 
-  /* "hash_ring/hash_ring.pyx":49
+  /* "hash_ring/hash_ring.pyx":77
  * 
  *     def remove_node(self, name):
  *         return hash_ring_remove_node(self._ring, name, len(name)) == HASH_RING_OK             # <<<<<<<<<<<<<<
@@ -1123,16 +1671,16 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(struct __
  *     def print_ring(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyObject_AsUString(__pyx_v_name); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 49, __pyx_L1_error)
-  __pyx_t_2 = PyObject_Length(__pyx_v_name); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 49, __pyx_L1_error)
-  __pyx_t_3 = __Pyx_PyBool_FromLong((hash_ring_remove_node(__pyx_v_self->_ring, __pyx_t_1, __pyx_t_2) == HASH_RING_OK)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 49, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_AsUString(__pyx_v_name); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_t_2 = PyObject_Length(__pyx_v_name); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyBool_FromLong((hash_ring_remove_node(__pyx_v_self->_ring, __pyx_t_1, __pyx_t_2) == HASH_RING_OK)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 77, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_r = __pyx_t_3;
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "hash_ring/hash_ring.pyx":48
- *         return hash_ring_add_node(self._ring, name, len(name), num_replicas) == HASH_RING_OK
+  /* "hash_ring/hash_ring.pyx":76
+ *         return hash_ring_sort(self._ring) == HASH_RING_OK
  * 
  *     def remove_node(self, name):             # <<<<<<<<<<<<<<
  *         return hash_ring_remove_node(self._ring, name, len(name)) == HASH_RING_OK
@@ -1150,7 +1698,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(struct __
   return __pyx_r;
 }
 
-/* "hash_ring/hash_ring.pyx":51
+/* "hash_ring/hash_ring.pyx":79
  *         return hash_ring_remove_node(self._ring, name, len(name)) == HASH_RING_OK
  * 
  *     def print_ring(self):             # <<<<<<<<<<<<<<
@@ -1159,24 +1707,24 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_6remove_node(struct __
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_9print_ring(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_9print_ring(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_11print_ring(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_11print_ring(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("print_ring (wrapper)", 0);
-  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_8print_ring(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self));
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_10print_ring(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8print_ring(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self) {
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10print_ring(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("print_ring", 0);
 
-  /* "hash_ring/hash_ring.pyx":52
+  /* "hash_ring/hash_ring.pyx":80
  * 
  *     def print_ring(self):
  *         hash_ring_print(self._ring)             # <<<<<<<<<<<<<<
@@ -1185,7 +1733,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8print_ring(struct __p
  */
   hash_ring_print(__pyx_v_self->_ring);
 
-  /* "hash_ring/hash_ring.pyx":51
+  /* "hash_ring/hash_ring.pyx":79
  *         return hash_ring_remove_node(self._ring, name, len(name)) == HASH_RING_OK
  * 
  *     def print_ring(self):             # <<<<<<<<<<<<<<
@@ -1200,7 +1748,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8print_ring(struct __p
   return __pyx_r;
 }
 
-/* "hash_ring/hash_ring.pyx":54
+/* "hash_ring/hash_ring.pyx":82
  *         hash_ring_print(self._ring)
  * 
  *     def find_node(self, key):             # <<<<<<<<<<<<<<
@@ -1209,19 +1757,19 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_8print_ring(struct __p
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_11find_node(PyObject *__pyx_v_self, PyObject *__pyx_v_key); /*proto*/
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_11find_node(PyObject *__pyx_v_self, PyObject *__pyx_v_key) {
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_node(PyObject *__pyx_v_self, PyObject *__pyx_v_key); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_node(PyObject *__pyx_v_self, PyObject *__pyx_v_key) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("find_node (wrapper)", 0);
-  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), ((PyObject *)__pyx_v_key));
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_node(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), ((PyObject *)__pyx_v_key));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key) {
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key) {
   hash_ring_node_t *__pyx_v_node;
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
@@ -1234,58 +1782,58 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(struct __p
   __Pyx_RefNannySetupContext("find_node", 0);
   __Pyx_INCREF(__pyx_v_key);
 
-  /* "hash_ring/hash_ring.pyx":55
+  /* "hash_ring/hash_ring.pyx":83
  * 
  *     def find_node(self, key):
  *         if not isinstance(key, bytes):             # <<<<<<<<<<<<<<
  *             key = bytes(key)
- *         node = hash_ring_find_node(self._ring, key, len(key))
+ * 
  */
   __pyx_t_1 = PyBytes_Check(__pyx_v_key); 
   __pyx_t_2 = ((!(__pyx_t_1 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "hash_ring/hash_ring.pyx":56
+    /* "hash_ring/hash_ring.pyx":84
  *     def find_node(self, key):
  *         if not isinstance(key, bytes):
  *             key = bytes(key)             # <<<<<<<<<<<<<<
+ * 
  *         node = hash_ring_find_node(self._ring, key, len(key))
- *         if node:
  */
-    __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 56, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 84, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_key);
     __Pyx_GIVEREF(__pyx_v_key);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_key);
-    __pyx_t_4 = __Pyx_PyObject_Call(((PyObject *)(&PyBytes_Type)), __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 56, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(((PyObject *)(&PyBytes_Type)), __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 84, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF_SET(__pyx_v_key, __pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* "hash_ring/hash_ring.pyx":55
+    /* "hash_ring/hash_ring.pyx":83
  * 
  *     def find_node(self, key):
  *         if not isinstance(key, bytes):             # <<<<<<<<<<<<<<
  *             key = bytes(key)
- *         node = hash_ring_find_node(self._ring, key, len(key))
+ * 
  */
   }
 
-  /* "hash_ring/hash_ring.pyx":57
- *         if not isinstance(key, bytes):
+  /* "hash_ring/hash_ring.pyx":86
  *             key = bytes(key)
+ * 
  *         node = hash_ring_find_node(self._ring, key, len(key))             # <<<<<<<<<<<<<<
+ * 
  *         if node:
- *             return node.name[:node.name_len]
  */
-  __pyx_t_5 = __Pyx_PyObject_AsUString(__pyx_v_key); if (unlikely((!__pyx_t_5) && PyErr_Occurred())) __PYX_ERR(0, 57, __pyx_L1_error)
-  __pyx_t_6 = PyObject_Length(__pyx_v_key); if (unlikely(__pyx_t_6 == -1)) __PYX_ERR(0, 57, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_AsUString(__pyx_v_key); if (unlikely((!__pyx_t_5) && PyErr_Occurred())) __PYX_ERR(0, 86, __pyx_L1_error)
+  __pyx_t_6 = PyObject_Length(__pyx_v_key); if (unlikely(__pyx_t_6 == -1)) __PYX_ERR(0, 86, __pyx_L1_error)
   __pyx_v_node = hash_ring_find_node(__pyx_v_self->_ring, __pyx_t_5, __pyx_t_6);
 
-  /* "hash_ring/hash_ring.pyx":58
- *             key = bytes(key)
+  /* "hash_ring/hash_ring.pyx":88
  *         node = hash_ring_find_node(self._ring, key, len(key))
+ * 
  *         if node:             # <<<<<<<<<<<<<<
  *             return node.name[:node.name_len]
  * 
@@ -1293,30 +1841,30 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(struct __p
   __pyx_t_2 = (__pyx_v_node != 0);
   if (__pyx_t_2) {
 
-    /* "hash_ring/hash_ring.pyx":59
- *         node = hash_ring_find_node(self._ring, key, len(key))
+    /* "hash_ring/hash_ring.pyx":89
+ * 
  *         if node:
  *             return node.name[:node.name_len]             # <<<<<<<<<<<<<<
  * 
  *     def find_nodes(self, key, num=1):
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_PyBytes_FromStringAndSize(((const char*)__pyx_v_node->name) + 0, __pyx_v_node->nameLen - 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 59, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyBytes_FromStringAndSize(((const char*)__pyx_v_node->name) + 0, __pyx_v_node->nameLen - 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 89, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_r = __pyx_t_4;
     __pyx_t_4 = 0;
     goto __pyx_L0;
 
-    /* "hash_ring/hash_ring.pyx":58
- *             key = bytes(key)
+    /* "hash_ring/hash_ring.pyx":88
  *         node = hash_ring_find_node(self._ring, key, len(key))
+ * 
  *         if node:             # <<<<<<<<<<<<<<
  *             return node.name[:node.name_len]
  * 
  */
   }
 
-  /* "hash_ring/hash_ring.pyx":54
+  /* "hash_ring/hash_ring.pyx":82
  *         hash_ring_print(self._ring)
  * 
  *     def find_node(self, key):             # <<<<<<<<<<<<<<
@@ -1339,7 +1887,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(struct __p
   return __pyx_r;
 }
 
-/* "hash_ring/hash_ring.pyx":61
+/* "hash_ring/hash_ring.pyx":91
  *             return node.name[:node.name_len]
  * 
  *     def find_nodes(self, key, num=1):             # <<<<<<<<<<<<<<
@@ -1348,8 +1896,8 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_10find_node(struct __p
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_nodes(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_nodes(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_15find_nodes(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_15find_nodes(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_key = 0;
   PyObject *__pyx_v_num = 0;
   PyObject *__pyx_r = 0;
@@ -1380,7 +1928,7 @@ static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_nodes(PyObject 
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "find_nodes") < 0)) __PYX_ERR(0, 61, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "find_nodes") < 0)) __PYX_ERR(0, 91, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -1395,20 +1943,20 @@ static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_nodes(PyObject 
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("find_nodes", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 61, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("find_nodes", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 91, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("hash_ring.hash_ring.HashRing.find_nodes", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), __pyx_v_key, __pyx_v_num);
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_14find_nodes(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), __pyx_v_key, __pyx_v_num);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_num) {
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_14find_nodes(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_key, PyObject *__pyx_v_num) {
   hash_ring_node_t **__pyx_v_nodes;
   int __pyx_v_n;
   hash_ring_node_t *__pyx_v_node;
@@ -1438,133 +1986,133 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(struct __
   __Pyx_RefNannySetupContext("find_nodes", 0);
   __Pyx_INCREF(__pyx_v_key);
 
-  /* "hash_ring/hash_ring.pyx":62
+  /* "hash_ring/hash_ring.pyx":92
  * 
  *     def find_nodes(self, key, num=1):
  *         if not isinstance(key, bytes):             # <<<<<<<<<<<<<<
  *             key = bytes(key)
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
+ * 
  */
   __pyx_t_1 = PyBytes_Check(__pyx_v_key); 
   __pyx_t_2 = ((!(__pyx_t_1 != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "hash_ring/hash_ring.pyx":63
+    /* "hash_ring/hash_ring.pyx":93
  *     def find_nodes(self, key, num=1):
  *         if not isinstance(key, bytes):
  *             key = bytes(key)             # <<<<<<<<<<<<<<
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
- *         if not nodes:
+ * 
+ *         cdef hash_ring_node_t ** nodes = <hash_ring_node_t **> malloc(sizeof(hash_ring_node_t *) * num)
  */
-    __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 63, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 93, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_key);
     __Pyx_GIVEREF(__pyx_v_key);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_key);
-    __pyx_t_4 = __Pyx_PyObject_Call(((PyObject *)(&PyBytes_Type)), __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 63, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(((PyObject *)(&PyBytes_Type)), __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 93, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF_SET(__pyx_v_key, __pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* "hash_ring/hash_ring.pyx":62
+    /* "hash_ring/hash_ring.pyx":92
  * 
  *     def find_nodes(self, key, num=1):
  *         if not isinstance(key, bytes):             # <<<<<<<<<<<<<<
  *             key = bytes(key)
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
+ * 
  */
   }
 
-  /* "hash_ring/hash_ring.pyx":64
- *         if not isinstance(key, bytes):
+  /* "hash_ring/hash_ring.pyx":95
  *             key = bytes(key)
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)             # <<<<<<<<<<<<<<
+ * 
+ *         cdef hash_ring_node_t ** nodes = <hash_ring_node_t **> malloc(sizeof(hash_ring_node_t *) * num)             # <<<<<<<<<<<<<<
  *         if not nodes:
  *             raise MemoryError()
  */
-  __pyx_t_4 = __Pyx_PyInt_FromSize_t((sizeof(hash_ring_node_t *))); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 64, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_FromSize_t((sizeof(hash_ring_node_t *))); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 95, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Multiply(__pyx_t_4, __pyx_v_num); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 64, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Multiply(__pyx_t_4, __pyx_v_num); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 95, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_5 = __Pyx_PyInt_As_size_t(__pyx_t_3); if (unlikely((__pyx_t_5 == (size_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 64, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_size_t(__pyx_t_3); if (unlikely((__pyx_t_5 == (size_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 95, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_nodes = ((hash_ring_node_t **)malloc(__pyx_t_5));
 
-  /* "hash_ring/hash_ring.pyx":65
- *             key = bytes(key)
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
+  /* "hash_ring/hash_ring.pyx":96
+ * 
+ *         cdef hash_ring_node_t ** nodes = <hash_ring_node_t **> malloc(sizeof(hash_ring_node_t *) * num)
  *         if not nodes:             # <<<<<<<<<<<<<<
  *             raise MemoryError()
- *         try:
+ * 
  */
   __pyx_t_2 = ((!(__pyx_v_nodes != 0)) != 0);
   if (__pyx_t_2) {
 
-    /* "hash_ring/hash_ring.pyx":66
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
+    /* "hash_ring/hash_ring.pyx":97
+ *         cdef hash_ring_node_t ** nodes = <hash_ring_node_t **> malloc(sizeof(hash_ring_node_t *) * num)
  *         if not nodes:
  *             raise MemoryError()             # <<<<<<<<<<<<<<
+ * 
  *         try:
- *             n = hash_ring_find_nodes(self._ring, key, len(key), nodes, num)
  */
-    PyErr_NoMemory(); __PYX_ERR(0, 66, __pyx_L1_error)
+    PyErr_NoMemory(); __PYX_ERR(0, 97, __pyx_L1_error)
 
-    /* "hash_ring/hash_ring.pyx":65
- *             key = bytes(key)
- *         cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
+    /* "hash_ring/hash_ring.pyx":96
+ * 
+ *         cdef hash_ring_node_t ** nodes = <hash_ring_node_t **> malloc(sizeof(hash_ring_node_t *) * num)
  *         if not nodes:             # <<<<<<<<<<<<<<
  *             raise MemoryError()
- *         try:
+ * 
  */
   }
 
-  /* "hash_ring/hash_ring.pyx":67
- *         if not nodes:
+  /* "hash_ring/hash_ring.pyx":99
  *             raise MemoryError()
+ * 
  *         try:             # <<<<<<<<<<<<<<
  *             n = hash_ring_find_nodes(self._ring, key, len(key), nodes, num)
  *             return [node.name[:node.name_len] for node in nodes[:n]] if n > -1 else []
  */
   /*try:*/ {
 
-    /* "hash_ring/hash_ring.pyx":68
- *             raise MemoryError()
+    /* "hash_ring/hash_ring.pyx":100
+ * 
  *         try:
  *             n = hash_ring_find_nodes(self._ring, key, len(key), nodes, num)             # <<<<<<<<<<<<<<
  *             return [node.name[:node.name_len] for node in nodes[:n]] if n > -1 else []
- *         finally:
+ * 
  */
-    __pyx_t_6 = __Pyx_PyObject_AsUString(__pyx_v_key); if (unlikely((!__pyx_t_6) && PyErr_Occurred())) __PYX_ERR(0, 68, __pyx_L6_error)
-    __pyx_t_7 = PyObject_Length(__pyx_v_key); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 68, __pyx_L6_error)
-    __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_v_num); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 68, __pyx_L6_error)
+    __pyx_t_6 = __Pyx_PyObject_AsUString(__pyx_v_key); if (unlikely((!__pyx_t_6) && PyErr_Occurred())) __PYX_ERR(0, 100, __pyx_L6_error)
+    __pyx_t_7 = PyObject_Length(__pyx_v_key); if (unlikely(__pyx_t_7 == -1)) __PYX_ERR(0, 100, __pyx_L6_error)
+    __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_v_num); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 100, __pyx_L6_error)
     __pyx_v_n = hash_ring_find_nodes(__pyx_v_self->_ring, __pyx_t_6, __pyx_t_7, __pyx_v_nodes, __pyx_t_8);
 
-    /* "hash_ring/hash_ring.pyx":69
+    /* "hash_ring/hash_ring.pyx":101
  *         try:
  *             n = hash_ring_find_nodes(self._ring, key, len(key), nodes, num)
  *             return [node.name[:node.name_len] for node in nodes[:n]] if n > -1 else []             # <<<<<<<<<<<<<<
+ * 
  *         finally:
- *             free(nodes)
  */
     __Pyx_XDECREF(__pyx_r);
     if (((__pyx_v_n > -1L) != 0)) {
-      __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 69, __pyx_L6_error)
+      __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 101, __pyx_L6_error)
       __Pyx_GOTREF(__pyx_t_4);
       __pyx_t_10 = (__pyx_v_nodes + __pyx_v_n);
       for (__pyx_t_11 = __pyx_v_nodes; __pyx_t_11 < __pyx_t_10; __pyx_t_11++) {
         __pyx_t_9 = __pyx_t_11;
         __pyx_v_node = (__pyx_t_9[0]);
-        __pyx_t_12 = __Pyx_PyBytes_FromStringAndSize(((const char*)__pyx_v_node->name) + 0, __pyx_v_node->nameLen - 0); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 69, __pyx_L6_error)
+        __pyx_t_12 = __Pyx_PyBytes_FromStringAndSize(((const char*)__pyx_v_node->name) + 0, __pyx_v_node->nameLen - 0); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 101, __pyx_L6_error)
         __Pyx_GOTREF(__pyx_t_12);
-        if (unlikely(__Pyx_ListComp_Append(__pyx_t_4, (PyObject*)__pyx_t_12))) __PYX_ERR(0, 69, __pyx_L6_error)
+        if (unlikely(__Pyx_ListComp_Append(__pyx_t_4, (PyObject*)__pyx_t_12))) __PYX_ERR(0, 101, __pyx_L6_error)
         __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
       }
       __pyx_t_3 = __pyx_t_4;
       __pyx_t_4 = 0;
     } else {
-      __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 69, __pyx_L6_error)
+      __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 101, __pyx_L6_error)
       __Pyx_GOTREF(__pyx_t_4);
       __pyx_t_3 = __pyx_t_4;
       __pyx_t_4 = 0;
@@ -1574,10 +2122,12 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(struct __
     goto __pyx_L5_return;
   }
 
-  /* "hash_ring/hash_ring.pyx":71
- *             return [node.name[:node.name_len] for node in nodes[:n]] if n > -1 else []
+  /* "hash_ring/hash_ring.pyx":104
+ * 
  *         finally:
  *             free(nodes)             # <<<<<<<<<<<<<<
+ * 
+ *     def get_num_items(self):
  */
   /*finally:*/ {
     /*exception exit:*/{
@@ -1625,7 +2175,7 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(struct __
     }
   }
 
-  /* "hash_ring/hash_ring.pyx":61
+  /* "hash_ring/hash_ring.pyx":91
  *             return node.name[:node.name_len]
  * 
  *     def find_nodes(self, key, num=1):             # <<<<<<<<<<<<<<
@@ -1642,6 +2192,306 @@ static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_12find_nodes(struct __
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XDECREF(__pyx_v_key);
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "hash_ring/hash_ring.pyx":106
+ *             free(nodes)
+ * 
+ *     def get_num_items(self):             # <<<<<<<<<<<<<<
+ *         return self._ring.num_items
+ * 
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_17get_num_items(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_17get_num_items(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("get_num_items (wrapper)", 0);
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_16get_num_items(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_16get_num_items(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("get_num_items", 0);
+
+  /* "hash_ring/hash_ring.pyx":107
+ * 
+ *     def get_num_items(self):
+ *         return self._ring.num_items             # <<<<<<<<<<<<<<
+ * 
+ *     def get_node(self, node_name):
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_self->_ring->numItems); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 107, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "hash_ring/hash_ring.pyx":106
+ *             free(nodes)
+ * 
+ *     def get_num_items(self):             # <<<<<<<<<<<<<<
+ *         return self._ring.num_items
+ * 
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("hash_ring.hash_ring.HashRing.get_num_items", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "hash_ring/hash_ring.pyx":109
+ *         return self._ring.num_items
+ * 
+ *     def get_node(self, node_name):             # <<<<<<<<<<<<<<
+ *         node = hash_ring_get_node(self._ring, node_name, len(node_name))
+ *         if not node:
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_19get_node(PyObject *__pyx_v_self, PyObject *__pyx_v_node_name); /*proto*/
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_8HashRing_19get_node(PyObject *__pyx_v_self, PyObject *__pyx_v_node_name) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("get_node (wrapper)", 0);
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_8HashRing_18get_node(((struct __pyx_obj_9hash_ring_9hash_ring_HashRing *)__pyx_v_self), ((PyObject *)__pyx_v_node_name));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_8HashRing_18get_node(struct __pyx_obj_9hash_ring_9hash_ring_HashRing *__pyx_v_self, PyObject *__pyx_v_node_name) {
+  hash_ring_node_t *__pyx_v_node;
+  PyObject *__pyx_r = NULL;
+  __Pyx_RefNannyDeclarations
+  unsigned char *__pyx_t_1;
+  Py_ssize_t __pyx_t_2;
+  int __pyx_t_3;
+  PyObject *__pyx_t_4 = NULL;
+  PyObject *__pyx_t_5 = NULL;
+  PyObject *__pyx_t_6 = NULL;
+  __Pyx_RefNannySetupContext("get_node", 0);
+
+  /* "hash_ring/hash_ring.pyx":110
+ * 
+ *     def get_node(self, node_name):
+ *         node = hash_ring_get_node(self._ring, node_name, len(node_name))             # <<<<<<<<<<<<<<
+ *         if not node:
+ *             return None
+ */
+  __pyx_t_1 = __Pyx_PyObject_AsUString(__pyx_v_node_name); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 110, __pyx_L1_error)
+  __pyx_t_2 = PyObject_Length(__pyx_v_node_name); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(0, 110, __pyx_L1_error)
+  __pyx_v_node = hash_ring_get_node(__pyx_v_self->_ring, __pyx_t_1, __pyx_t_2);
+
+  /* "hash_ring/hash_ring.pyx":111
+ *     def get_node(self, node_name):
+ *         node = hash_ring_get_node(self._ring, node_name, len(node_name))
+ *         if not node:             # <<<<<<<<<<<<<<
+ *             return None
+ * 
+ */
+  __pyx_t_3 = ((!(__pyx_v_node != 0)) != 0);
+  if (__pyx_t_3) {
+
+    /* "hash_ring/hash_ring.pyx":112
+ *         node = hash_ring_get_node(self._ring, node_name, len(node_name))
+ *         if not node:
+ *             return None             # <<<<<<<<<<<<<<
+ * 
+ *         return HashRingNode(name=node.name[:node.name_len], num_replicas=node.num_replicas)
+ */
+    __Pyx_XDECREF(__pyx_r);
+    __Pyx_INCREF(Py_None);
+    __pyx_r = Py_None;
+    goto __pyx_L0;
+
+    /* "hash_ring/hash_ring.pyx":111
+ *     def get_node(self, node_name):
+ *         node = hash_ring_get_node(self._ring, node_name, len(node_name))
+ *         if not node:             # <<<<<<<<<<<<<<
+ *             return None
+ * 
+ */
+  }
+
+  /* "hash_ring/hash_ring.pyx":114
+ *             return None
+ * 
+ *         return HashRingNode(name=node.name[:node.name_len], num_replicas=node.num_replicas)             # <<<<<<<<<<<<<<
+ * 
+ * class HashRingNode:
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_HashRingNode); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __pyx_t_5 = PyDict_New(); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_5);
+  __pyx_t_6 = __Pyx_PyBytes_FromStringAndSize(((const char*)__pyx_v_node->name) + 0, __pyx_v_node->nameLen - 0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_6);
+  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_name, __pyx_t_6) < 0) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
+  __pyx_t_6 = __Pyx_PyInt_From_unsigned_int(__pyx_v_node->numReplicas); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_6);
+  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_num_replicas, __pyx_t_6) < 0) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
+  __pyx_t_6 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_empty_tuple, __pyx_t_5); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 114, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_6);
+  __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  __pyx_r = __pyx_t_6;
+  __pyx_t_6 = 0;
+  goto __pyx_L0;
+
+  /* "hash_ring/hash_ring.pyx":109
+ *         return self._ring.num_items
+ * 
+ *     def get_node(self, node_name):             # <<<<<<<<<<<<<<
+ *         node = hash_ring_get_node(self._ring, node_name, len(node_name))
+ *         if not node:
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_XDECREF(__pyx_t_5);
+  __Pyx_XDECREF(__pyx_t_6);
+  __Pyx_AddTraceback("hash_ring.hash_ring.HashRing.get_node", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "hash_ring/hash_ring.pyx":117
+ * 
+ * class HashRingNode:
+ *     def __init__(self, name, num_replicas):             # <<<<<<<<<<<<<<
+ *         self.name = name
+ *         self.num_replicas = num_replicas
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_12HashRingNode_1__init__(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
+static PyMethodDef __pyx_mdef_9hash_ring_9hash_ring_12HashRingNode_1__init__ = {"__init__", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_12HashRingNode_1__init__, METH_VARARGS|METH_KEYWORDS, 0};
+static PyObject *__pyx_pw_9hash_ring_9hash_ring_12HashRingNode_1__init__(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
+  PyObject *__pyx_v_self = 0;
+  PyObject *__pyx_v_name = 0;
+  PyObject *__pyx_v_num_replicas = 0;
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__init__ (wrapper)", 0);
+  {
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_name,&__pyx_n_s_num_replicas,0};
+    PyObject* values[3] = {0,0,0};
+    if (unlikely(__pyx_kwds)) {
+      Py_ssize_t kw_args;
+      const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
+      switch (pos_args) {
+        case  3: values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
+        case  2: values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
+        case  1: values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
+        case  0: break;
+        default: goto __pyx_L5_argtuple_error;
+      }
+      kw_args = PyDict_Size(__pyx_kwds);
+      switch (pos_args) {
+        case  0:
+        if (likely((values[0] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_self)) != 0)) kw_args--;
+        else goto __pyx_L5_argtuple_error;
+        case  1:
+        if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_name)) != 0)) kw_args--;
+        else {
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 3, 3, 1); __PYX_ERR(0, 117, __pyx_L3_error)
+        }
+        case  2:
+        if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_num_replicas)) != 0)) kw_args--;
+        else {
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 3, 3, 2); __PYX_ERR(0, 117, __pyx_L3_error)
+        }
+      }
+      if (unlikely(kw_args > 0)) {
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 117, __pyx_L3_error)
+      }
+    } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
+      goto __pyx_L5_argtuple_error;
+    } else {
+      values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
+      values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
+      values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
+    }
+    __pyx_v_self = values[0];
+    __pyx_v_name = values[1];
+    __pyx_v_num_replicas = values[2];
+  }
+  goto __pyx_L4_argument_unpacking_done;
+  __pyx_L5_argtuple_error:;
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 117, __pyx_L3_error)
+  __pyx_L3_error:;
+  __Pyx_AddTraceback("hash_ring.hash_ring.HashRingNode.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_RefNannyFinishContext();
+  return NULL;
+  __pyx_L4_argument_unpacking_done:;
+  __pyx_r = __pyx_pf_9hash_ring_9hash_ring_12HashRingNode___init__(__pyx_self, __pyx_v_self, __pyx_v_name, __pyx_v_num_replicas);
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_9hash_ring_9hash_ring_12HashRingNode___init__(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_name, PyObject *__pyx_v_num_replicas) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__init__", 0);
+
+  /* "hash_ring/hash_ring.pyx":118
+ * class HashRingNode:
+ *     def __init__(self, name, num_replicas):
+ *         self.name = name             # <<<<<<<<<<<<<<
+ *         self.num_replicas = num_replicas
+ */
+  if (__Pyx_PyObject_SetAttrStr(__pyx_v_self, __pyx_n_s_name, __pyx_v_name) < 0) __PYX_ERR(0, 118, __pyx_L1_error)
+
+  /* "hash_ring/hash_ring.pyx":119
+ *     def __init__(self, name, num_replicas):
+ *         self.name = name
+ *         self.num_replicas = num_replicas             # <<<<<<<<<<<<<<
+ */
+  if (__Pyx_PyObject_SetAttrStr(__pyx_v_self, __pyx_n_s_num_replicas, __pyx_v_num_replicas) < 0) __PYX_ERR(0, 119, __pyx_L1_error)
+
+  /* "hash_ring/hash_ring.pyx":117
+ * 
+ * class HashRingNode:
+ *     def __init__(self, name, num_replicas):             # <<<<<<<<<<<<<<
+ *         self.name = name
+ *         self.num_replicas = num_replicas
+ */
+
+  /* function exit code */
+  __pyx_r = Py_None; __Pyx_INCREF(Py_None);
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_AddTraceback("hash_ring.hash_ring.HashRingNode.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
@@ -1680,10 +2530,13 @@ static void __pyx_tp_dealloc_9hash_ring_9hash_ring_HashRing(PyObject *o) {
 
 static PyMethodDef __pyx_methods_9hash_ring_9hash_ring_HashRing[] = {
   {"add_node", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_5add_node, METH_VARARGS|METH_KEYWORDS, 0},
-  {"remove_node", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_7remove_node, METH_O, 0},
-  {"print_ring", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_9print_ring, METH_NOARGS, 0},
-  {"find_node", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_11find_node, METH_O, 0},
-  {"find_nodes", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_nodes, METH_VARARGS|METH_KEYWORDS, 0},
+  {"add_nodes", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_7add_nodes, METH_O, 0},
+  {"remove_node", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_9remove_node, METH_O, 0},
+  {"print_ring", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_11print_ring, METH_NOARGS, 0},
+  {"find_node", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_13find_node, METH_O, 0},
+  {"find_nodes", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_15find_nodes, METH_VARARGS|METH_KEYWORDS, 0},
+  {"get_num_items", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_17get_num_items, METH_NOARGS, 0},
+  {"get_node", (PyCFunction)__pyx_pw_9hash_ring_9hash_ring_8HashRing_19get_node, METH_O, 0},
   {0, 0, 0, 0}
 };
 
@@ -1770,19 +2623,31 @@ static struct PyModuleDef __pyx_moduledef = {
 static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_HASH_FUNCTION_MD5, __pyx_k_HASH_FUNCTION_MD5, sizeof(__pyx_k_HASH_FUNCTION_MD5), 0, 0, 1, 1},
   {&__pyx_n_s_HASH_FUNCTION_SHA1, __pyx_k_HASH_FUNCTION_SHA1, sizeof(__pyx_k_HASH_FUNCTION_SHA1), 0, 0, 1, 1},
+  {&__pyx_n_s_HashRingNode, __pyx_k_HashRingNode, sizeof(__pyx_k_HashRingNode), 0, 0, 1, 1},
+  {&__pyx_n_s_HashRingNode___init, __pyx_k_HashRingNode___init, sizeof(__pyx_k_HashRingNode___init), 0, 0, 1, 1},
   {&__pyx_n_s_MemoryError, __pyx_k_MemoryError, sizeof(__pyx_k_MemoryError), 0, 0, 1, 1},
+  {&__pyx_kp_s_Users_jake_PycharmProjects_hash, __pyx_k_Users_jake_PycharmProjects_hash, sizeof(__pyx_k_Users_jake_PycharmProjects_hash), 0, 0, 1, 0},
   {&__pyx_n_s_default_num_replicas, __pyx_k_default_num_replicas, sizeof(__pyx_k_default_num_replicas), 0, 0, 1, 1},
+  {&__pyx_n_s_doc, __pyx_k_doc, sizeof(__pyx_k_doc), 0, 0, 1, 1},
+  {&__pyx_n_s_get_num_items, __pyx_k_get_num_items, sizeof(__pyx_k_get_num_items), 0, 0, 1, 1},
   {&__pyx_n_s_hash_fn, __pyx_k_hash_fn, sizeof(__pyx_k_hash_fn), 0, 0, 1, 1},
+  {&__pyx_n_s_hash_ring_hash_ring, __pyx_k_hash_ring_hash_ring, sizeof(__pyx_k_hash_ring_hash_ring), 0, 0, 1, 1},
+  {&__pyx_n_s_init, __pyx_k_init, sizeof(__pyx_k_init), 0, 0, 1, 1},
   {&__pyx_n_s_key, __pyx_k_key, sizeof(__pyx_k_key), 0, 0, 1, 1},
   {&__pyx_n_s_main, __pyx_k_main, sizeof(__pyx_k_main), 0, 0, 1, 1},
+  {&__pyx_n_s_metaclass, __pyx_k_metaclass, sizeof(__pyx_k_metaclass), 0, 0, 1, 1},
+  {&__pyx_n_s_module, __pyx_k_module, sizeof(__pyx_k_module), 0, 0, 1, 1},
   {&__pyx_n_s_name, __pyx_k_name, sizeof(__pyx_k_name), 0, 0, 1, 1},
   {&__pyx_n_s_num, __pyx_k_num, sizeof(__pyx_k_num), 0, 0, 1, 1},
   {&__pyx_n_s_num_replicas, __pyx_k_num_replicas, sizeof(__pyx_k_num_replicas), 0, 0, 1, 1},
+  {&__pyx_n_s_prepare, __pyx_k_prepare, sizeof(__pyx_k_prepare), 0, 0, 1, 1},
+  {&__pyx_n_s_qualname, __pyx_k_qualname, sizeof(__pyx_k_qualname), 0, 0, 1, 1},
+  {&__pyx_n_s_self, __pyx_k_self, sizeof(__pyx_k_self), 0, 0, 1, 1},
   {&__pyx_n_s_test, __pyx_k_test, sizeof(__pyx_k_test), 0, 0, 1, 1},
   {0, 0, 0, 0, 0, 0, 0}
 };
 static int __Pyx_InitCachedBuiltins(void) {
-  __pyx_builtin_MemoryError = __Pyx_GetBuiltinName(__pyx_n_s_MemoryError); if (!__pyx_builtin_MemoryError) __PYX_ERR(0, 66, __pyx_L1_error)
+  __pyx_builtin_MemoryError = __Pyx_GetBuiltinName(__pyx_n_s_MemoryError); if (!__pyx_builtin_MemoryError) __PYX_ERR(0, 97, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -1791,12 +2656,28 @@ static int __Pyx_InitCachedBuiltins(void) {
 static int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
+
+  /* "hash_ring/hash_ring.pyx":117
+ * 
+ * class HashRingNode:
+ *     def __init__(self, name, num_replicas):             # <<<<<<<<<<<<<<
+ *         self.name = name
+ *         self.num_replicas = num_replicas
+ */
+  __pyx_tuple__2 = PyTuple_Pack(3, __pyx_n_s_self, __pyx_n_s_name, __pyx_n_s_num_replicas); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(0, 117, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__2);
+  __Pyx_GIVEREF(__pyx_tuple__2);
+  __pyx_codeobj__3 = (PyObject*)__Pyx_PyCode_New(3, 0, 3, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__2, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_Users_jake_PycharmProjects_hash, __pyx_n_s_init, 117, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__3)) __PYX_ERR(0, 117, __pyx_L1_error)
   __Pyx_RefNannyFinishContext();
   return 0;
+  __pyx_L1_error:;
+  __Pyx_RefNannyFinishContext();
+  return -1;
 }
 
 static int __Pyx_InitGlobals(void) {
   if (__Pyx_InitStrings(__pyx_string_tab) < 0) __PYX_ERR(0, 1, __pyx_L1_error);
+  __pyx_int_0 = PyInt_FromLong(0); if (unlikely(!__pyx_int_0)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_1 = PyInt_FromLong(1); if (unlikely(!__pyx_int_1)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_128 = PyInt_FromLong(128); if (unlikely(!__pyx_int_128)) __PYX_ERR(0, 1, __pyx_L1_error)
   return 0;
@@ -1813,6 +2694,7 @@ PyMODINIT_FUNC PyInit_hash_ring(void)
 #endif
 {
   PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannyDeclarations
   #if CYTHON_REFNANNY
   __Pyx_RefNanny = __Pyx_RefNannyImportAPI("refnanny");
@@ -1888,9 +2770,9 @@ PyMODINIT_FUNC PyInit_hash_ring(void)
   /*--- Variable export code ---*/
   /*--- Function export code ---*/
   /*--- Type init code ---*/
-  if (PyType_Ready(&__pyx_type_9hash_ring_9hash_ring_HashRing) < 0) __PYX_ERR(0, 31, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_9hash_ring_9hash_ring_HashRing) < 0) __PYX_ERR(0, 35, __pyx_L1_error)
   __pyx_type_9hash_ring_9hash_ring_HashRing.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "HashRing", (PyObject *)&__pyx_type_9hash_ring_9hash_ring_HashRing) < 0) __PYX_ERR(0, 31, __pyx_L1_error)
+  if (PyObject_SetAttrString(__pyx_m, "HashRing", (PyObject *)&__pyx_type_9hash_ring_9hash_ring_HashRing) < 0) __PYX_ERR(0, 35, __pyx_L1_error)
   __pyx_ptype_9hash_ring_9hash_ring_HashRing = &__pyx_type_9hash_ring_9hash_ring_HashRing;
   /*--- Type import code ---*/
   /*--- Variable import code ---*/
@@ -1900,42 +2782,77 @@ PyMODINIT_FUNC PyInit_hash_ring(void)
   if (__Pyx_patch_abc() < 0) __PYX_ERR(0, 1, __pyx_L1_error)
   #endif
 
-  /* "hash_ring/hash_ring.pyx":28
- *     void hash_ring_print(hash_ring_t *ring)
+  /* "hash_ring/hash_ring.pyx":33
+ *     int hash_ring_sort(hash_ring_t *ring)
  * 
  * HASH_FUNCTION_SHA1 = _HASH_FUNCTION_SHA1             # <<<<<<<<<<<<<<
  * HASH_FUNCTION_MD5 = _HASH_FUNCTION_MD5
- * 
+ * cdef class HashRing:
  */
-  __pyx_t_1 = __Pyx_PyInt_From_HASH_FUNCTION(HASH_FUNCTION_SHA1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 28, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_HASH_FUNCTION(HASH_FUNCTION_SHA1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 33, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_HASH_FUNCTION_SHA1, __pyx_t_1) < 0) __PYX_ERR(0, 28, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_HASH_FUNCTION_SHA1, __pyx_t_1) < 0) __PYX_ERR(0, 33, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "hash_ring/hash_ring.pyx":29
+  /* "hash_ring/hash_ring.pyx":34
  * 
  * HASH_FUNCTION_SHA1 = _HASH_FUNCTION_SHA1
  * HASH_FUNCTION_MD5 = _HASH_FUNCTION_MD5             # <<<<<<<<<<<<<<
- * 
  * cdef class HashRing:
+ *     cdef hash_ring_t *_ring
  */
-  __pyx_t_1 = __Pyx_PyInt_From_HASH_FUNCTION(HASH_FUNCTION_MD5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 29, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_HASH_FUNCTION(HASH_FUNCTION_MD5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 34, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_HASH_FUNCTION_MD5, __pyx_t_1) < 0) __PYX_ERR(0, 29, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_HASH_FUNCTION_MD5, __pyx_t_1) < 0) __PYX_ERR(0, 34, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "hash_ring/hash_ring.pyx":35
+  /* "hash_ring/hash_ring.pyx":39
  *     cdef unsigned int _default_num_replicas
  * 
  *     def __cinit__(self, default_num_replicas=128, hash_fn=HASH_FUNCTION_MD5):             # <<<<<<<<<<<<<<
  *         self._ring = hash_ring_create(hash_fn)
  *         self._default_num_replicas = default_num_replicas
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_HASH_FUNCTION_MD5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 35, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_HASH_FUNCTION_MD5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 39, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_k_ = __pyx_t_1;
   __Pyx_GIVEREF(__pyx_t_1);
   __pyx_t_1 = 0;
+
+  /* "hash_ring/hash_ring.pyx":116
+ *         return HashRingNode(name=node.name[:node.name_len], num_replicas=node.num_replicas)
+ * 
+ * class HashRingNode:             # <<<<<<<<<<<<<<
+ *     def __init__(self, name, num_replicas):
+ *         self.name = name
+ */
+  __pyx_t_1 = __Pyx_Py3MetaclassPrepare((PyObject *) NULL, __pyx_empty_tuple, __pyx_n_s_HashRingNode, __pyx_n_s_HashRingNode, (PyObject *) NULL, __pyx_n_s_hash_ring_hash_ring, (PyObject *) NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 116, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+
+  /* "hash_ring/hash_ring.pyx":117
+ * 
+ * class HashRingNode:
+ *     def __init__(self, name, num_replicas):             # <<<<<<<<<<<<<<
+ *         self.name = name
+ *         self.num_replicas = num_replicas
+ */
+  __pyx_t_2 = __Pyx_CyFunction_NewEx(&__pyx_mdef_9hash_ring_9hash_ring_12HashRingNode_1__init__, 0, __pyx_n_s_HashRingNode___init, NULL, __pyx_n_s_hash_ring_hash_ring, __pyx_d, ((PyObject *)__pyx_codeobj__3)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 117, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyObject_SetItem(__pyx_t_1, __pyx_n_s_init, __pyx_t_2) < 0) __PYX_ERR(0, 117, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+
+  /* "hash_ring/hash_ring.pyx":116
+ *         return HashRingNode(name=node.name[:node.name_len], num_replicas=node.num_replicas)
+ * 
+ * class HashRingNode:             # <<<<<<<<<<<<<<
+ *     def __init__(self, name, num_replicas):
+ *         self.name = name
+ */
+  __pyx_t_2 = __Pyx_Py3ClassCreate(((PyObject*)&__Pyx_DefaultClassType), __pyx_n_s_HashRingNode, __pyx_empty_tuple, __pyx_t_1, NULL, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 116, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_HashRingNode, __pyx_t_2) < 0) __PYX_ERR(0, 116, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
   /* "hash_ring/hash_ring.pyx":1
  * from libc.stdlib cimport malloc, free             # <<<<<<<<<<<<<<
@@ -1952,6 +2869,7 @@ PyMODINIT_FUNC PyInit_hash_ring(void)
   goto __pyx_L0;
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
   if (__pyx_m) {
     if (__pyx_d) {
       __Pyx_AddTraceback("init hash_ring.hash_ring", __pyx_clineno, __pyx_lineno, __pyx_filename);
@@ -2163,8 +3081,79 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_Call(PyObject *func, PyObject *arg
 }
 #endif
 
-/* PyErrFetchRestore */
+/* PyObjectCallMethO */
 #if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallMethO(PyObject *func, PyObject *arg) {
+    PyObject *self, *result;
+    PyCFunction cfunc;
+    cfunc = PyCFunction_GET_FUNCTION(func);
+    self = PyCFunction_GET_SELF(func);
+    if (unlikely(Py_EnterRecursiveCall((char*)" while calling a Python object")))
+        return NULL;
+    result = cfunc(self, arg);
+    Py_LeaveRecursiveCall();
+    if (unlikely(!result) && unlikely(!PyErr_Occurred())) {
+        PyErr_SetString(
+            PyExc_SystemError,
+            "NULL result without error in PyObject_Call");
+    }
+    return result;
+}
+#endif
+
+/* PyObjectCallOneArg */
+#if CYTHON_COMPILING_IN_CPYTHON
+static PyObject* __Pyx__PyObject_CallOneArg(PyObject *func, PyObject *arg) {
+    PyObject *result;
+    PyObject *args = PyTuple_New(1);
+    if (unlikely(!args)) return NULL;
+    Py_INCREF(arg);
+    PyTuple_SET_ITEM(args, 0, arg);
+    result = __Pyx_PyObject_Call(func, args, NULL);
+    Py_DECREF(args);
+    return result;
+}
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObject *arg) {
+#ifdef __Pyx_CyFunction_USED
+    if (likely(PyCFunction_Check(func) || PyObject_TypeCheck(func, __pyx_CyFunctionType))) {
+#else
+    if (likely(PyCFunction_Check(func))) {
+#endif
+        if (likely(PyCFunction_GET_FLAGS(func) & METH_O)) {
+            return __Pyx_PyObject_CallMethO(func, arg);
+        }
+    }
+    return __Pyx__PyObject_CallOneArg(func, arg);
+}
+#else
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObject *arg) {
+    PyObject *result;
+    PyObject *args = PyTuple_Pack(1, arg);
+    if (unlikely(!args)) return NULL;
+    result = __Pyx_PyObject_Call(func, args, NULL);
+    Py_DECREF(args);
+    return result;
+}
+#endif
+
+/* PyObjectCallNoArg */
+  #if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
+#ifdef __Pyx_CyFunction_USED
+    if (likely(PyCFunction_Check(func) || PyObject_TypeCheck(func, __pyx_CyFunctionType))) {
+#else
+    if (likely(PyCFunction_Check(func))) {
+#endif
+        if (likely(PyCFunction_GET_FLAGS(func) & METH_NOARGS)) {
+            return __Pyx_PyObject_CallMethO(func, NULL);
+        }
+    }
+    return __Pyx_PyObject_Call(func, __pyx_empty_tuple, NULL);
+}
+#endif
+
+/* PyErrFetchRestore */
+    #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE void __Pyx_ErrRestoreInState(PyThreadState *tstate, PyObject *type, PyObject *value, PyObject *tb) {
     PyObject *tmp_type, *tmp_value, *tmp_tb;
     tmp_type = tstate->curexc_type;
@@ -2188,7 +3177,7 @@ static CYTHON_INLINE void __Pyx_ErrFetchInState(PyThreadState *tstate, PyObject 
 #endif
 
 /* GetException */
-#if CYTHON_COMPILING_IN_CPYTHON
+    #if CYTHON_COMPILING_IN_CPYTHON
 static int __Pyx__GetException(PyThreadState *tstate, PyObject **type, PyObject **value, PyObject **tb) {
 #else
 static int __Pyx_GetException(PyObject **type, PyObject **value, PyObject **tb) {
@@ -2249,7 +3238,7 @@ bad:
 }
 
 /* SwapException */
-  #if CYTHON_COMPILING_IN_CPYTHON
+      #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE void __Pyx__ExceptionSwap(PyThreadState *tstate, PyObject **type, PyObject **value, PyObject **tb) {
     PyObject *tmp_type, *tmp_value, *tmp_tb;
     tmp_type = tstate->exc_type;
@@ -2274,7 +3263,7 @@ static CYTHON_INLINE void __Pyx_ExceptionSwap(PyObject **type, PyObject **value,
 #endif
 
 /* SaveResetException */
-  #if CYTHON_COMPILING_IN_CPYTHON
+      #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE void __Pyx__ExceptionSave(PyThreadState *tstate, PyObject **type, PyObject **value, PyObject **tb) {
     *type = tstate->exc_type;
     *value = tstate->exc_value;
@@ -2298,7 +3287,7 @@ static CYTHON_INLINE void __Pyx__ExceptionReset(PyThreadState *tstate, PyObject 
 #endif
 
 /* GetModuleGlobalName */
-  static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name) {
+      static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name) {
     PyObject *result;
 #if CYTHON_COMPILING_IN_CPYTHON
     result = PyDict_GetItem(__pyx_d, name);
@@ -2315,8 +3304,720 @@ static CYTHON_INLINE void __Pyx__ExceptionReset(PyThreadState *tstate, PyObject 
     return result;
 }
 
+/* FetchCommonType */
+        static PyTypeObject* __Pyx_FetchCommonType(PyTypeObject* type) {
+    PyObject* fake_module;
+    PyTypeObject* cached_type = NULL;
+    fake_module = PyImport_AddModule((char*) "_cython_" CYTHON_ABI);
+    if (!fake_module) return NULL;
+    Py_INCREF(fake_module);
+    cached_type = (PyTypeObject*) PyObject_GetAttrString(fake_module, type->tp_name);
+    if (cached_type) {
+        if (!PyType_Check((PyObject*)cached_type)) {
+            PyErr_Format(PyExc_TypeError,
+                "Shared Cython type %.200s is not a type object",
+                type->tp_name);
+            goto bad;
+        }
+        if (cached_type->tp_basicsize != type->tp_basicsize) {
+            PyErr_Format(PyExc_TypeError,
+                "Shared Cython type %.200s has the wrong size, try recompiling",
+                type->tp_name);
+            goto bad;
+        }
+    } else {
+        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) goto bad;
+        PyErr_Clear();
+        if (PyType_Ready(type) < 0) goto bad;
+        if (PyObject_SetAttrString(fake_module, type->tp_name, (PyObject*) type) < 0)
+            goto bad;
+        Py_INCREF(type);
+        cached_type = type;
+    }
+done:
+    Py_DECREF(fake_module);
+    return cached_type;
+bad:
+    Py_XDECREF(cached_type);
+    cached_type = NULL;
+    goto done;
+}
+
+/* CythonFunction */
+        static PyObject *
+__Pyx_CyFunction_get_doc(__pyx_CyFunctionObject *op, CYTHON_UNUSED void *closure)
+{
+    if (unlikely(op->func_doc == NULL)) {
+        if (op->func.m_ml->ml_doc) {
+#if PY_MAJOR_VERSION >= 3
+            op->func_doc = PyUnicode_FromString(op->func.m_ml->ml_doc);
+#else
+            op->func_doc = PyString_FromString(op->func.m_ml->ml_doc);
+#endif
+            if (unlikely(op->func_doc == NULL))
+                return NULL;
+        } else {
+            Py_INCREF(Py_None);
+            return Py_None;
+        }
+    }
+    Py_INCREF(op->func_doc);
+    return op->func_doc;
+}
+static int
+__Pyx_CyFunction_set_doc(__pyx_CyFunctionObject *op, PyObject *value)
+{
+    PyObject *tmp = op->func_doc;
+    if (value == NULL) {
+        value = Py_None;
+    }
+    Py_INCREF(value);
+    op->func_doc = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_name(__pyx_CyFunctionObject *op)
+{
+    if (unlikely(op->func_name == NULL)) {
+#if PY_MAJOR_VERSION >= 3
+        op->func_name = PyUnicode_InternFromString(op->func.m_ml->ml_name);
+#else
+        op->func_name = PyString_InternFromString(op->func.m_ml->ml_name);
+#endif
+        if (unlikely(op->func_name == NULL))
+            return NULL;
+    }
+    Py_INCREF(op->func_name);
+    return op->func_name;
+}
+static int
+__Pyx_CyFunction_set_name(__pyx_CyFunctionObject *op, PyObject *value)
+{
+    PyObject *tmp;
+#if PY_MAJOR_VERSION >= 3
+    if (unlikely(value == NULL || !PyUnicode_Check(value))) {
+#else
+    if (unlikely(value == NULL || !PyString_Check(value))) {
+#endif
+        PyErr_SetString(PyExc_TypeError,
+                        "__name__ must be set to a string object");
+        return -1;
+    }
+    tmp = op->func_name;
+    Py_INCREF(value);
+    op->func_name = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_qualname(__pyx_CyFunctionObject *op)
+{
+    Py_INCREF(op->func_qualname);
+    return op->func_qualname;
+}
+static int
+__Pyx_CyFunction_set_qualname(__pyx_CyFunctionObject *op, PyObject *value)
+{
+    PyObject *tmp;
+#if PY_MAJOR_VERSION >= 3
+    if (unlikely(value == NULL || !PyUnicode_Check(value))) {
+#else
+    if (unlikely(value == NULL || !PyString_Check(value))) {
+#endif
+        PyErr_SetString(PyExc_TypeError,
+                        "__qualname__ must be set to a string object");
+        return -1;
+    }
+    tmp = op->func_qualname;
+    Py_INCREF(value);
+    op->func_qualname = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_self(__pyx_CyFunctionObject *m, CYTHON_UNUSED void *closure)
+{
+    PyObject *self;
+    self = m->func_closure;
+    if (self == NULL)
+        self = Py_None;
+    Py_INCREF(self);
+    return self;
+}
+static PyObject *
+__Pyx_CyFunction_get_dict(__pyx_CyFunctionObject *op)
+{
+    if (unlikely(op->func_dict == NULL)) {
+        op->func_dict = PyDict_New();
+        if (unlikely(op->func_dict == NULL))
+            return NULL;
+    }
+    Py_INCREF(op->func_dict);
+    return op->func_dict;
+}
+static int
+__Pyx_CyFunction_set_dict(__pyx_CyFunctionObject *op, PyObject *value)
+{
+    PyObject *tmp;
+    if (unlikely(value == NULL)) {
+        PyErr_SetString(PyExc_TypeError,
+               "function's dictionary may not be deleted");
+        return -1;
+    }
+    if (unlikely(!PyDict_Check(value))) {
+        PyErr_SetString(PyExc_TypeError,
+               "setting function's dictionary to a non-dict");
+        return -1;
+    }
+    tmp = op->func_dict;
+    Py_INCREF(value);
+    op->func_dict = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_globals(__pyx_CyFunctionObject *op)
+{
+    Py_INCREF(op->func_globals);
+    return op->func_globals;
+}
+static PyObject *
+__Pyx_CyFunction_get_closure(CYTHON_UNUSED __pyx_CyFunctionObject *op)
+{
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+static PyObject *
+__Pyx_CyFunction_get_code(__pyx_CyFunctionObject *op)
+{
+    PyObject* result = (op->func_code) ? op->func_code : Py_None;
+    Py_INCREF(result);
+    return result;
+}
+static int
+__Pyx_CyFunction_init_defaults(__pyx_CyFunctionObject *op) {
+    int result = 0;
+    PyObject *res = op->defaults_getter((PyObject *) op);
+    if (unlikely(!res))
+        return -1;
+    #if CYTHON_COMPILING_IN_CPYTHON
+    op->defaults_tuple = PyTuple_GET_ITEM(res, 0);
+    Py_INCREF(op->defaults_tuple);
+    op->defaults_kwdict = PyTuple_GET_ITEM(res, 1);
+    Py_INCREF(op->defaults_kwdict);
+    #else
+    op->defaults_tuple = PySequence_ITEM(res, 0);
+    if (unlikely(!op->defaults_tuple)) result = -1;
+    else {
+        op->defaults_kwdict = PySequence_ITEM(res, 1);
+        if (unlikely(!op->defaults_kwdict)) result = -1;
+    }
+    #endif
+    Py_DECREF(res);
+    return result;
+}
+static int
+__Pyx_CyFunction_set_defaults(__pyx_CyFunctionObject *op, PyObject* value) {
+    PyObject* tmp;
+    if (!value) {
+        value = Py_None;
+    } else if (value != Py_None && !PyTuple_Check(value)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "__defaults__ must be set to a tuple object");
+        return -1;
+    }
+    Py_INCREF(value);
+    tmp = op->defaults_tuple;
+    op->defaults_tuple = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_defaults(__pyx_CyFunctionObject *op) {
+    PyObject* result = op->defaults_tuple;
+    if (unlikely(!result)) {
+        if (op->defaults_getter) {
+            if (__Pyx_CyFunction_init_defaults(op) < 0) return NULL;
+            result = op->defaults_tuple;
+        } else {
+            result = Py_None;
+        }
+    }
+    Py_INCREF(result);
+    return result;
+}
+static int
+__Pyx_CyFunction_set_kwdefaults(__pyx_CyFunctionObject *op, PyObject* value) {
+    PyObject* tmp;
+    if (!value) {
+        value = Py_None;
+    } else if (value != Py_None && !PyDict_Check(value)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "__kwdefaults__ must be set to a dict object");
+        return -1;
+    }
+    Py_INCREF(value);
+    tmp = op->defaults_kwdict;
+    op->defaults_kwdict = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_kwdefaults(__pyx_CyFunctionObject *op) {
+    PyObject* result = op->defaults_kwdict;
+    if (unlikely(!result)) {
+        if (op->defaults_getter) {
+            if (__Pyx_CyFunction_init_defaults(op) < 0) return NULL;
+            result = op->defaults_kwdict;
+        } else {
+            result = Py_None;
+        }
+    }
+    Py_INCREF(result);
+    return result;
+}
+static int
+__Pyx_CyFunction_set_annotations(__pyx_CyFunctionObject *op, PyObject* value) {
+    PyObject* tmp;
+    if (!value || value == Py_None) {
+        value = NULL;
+    } else if (!PyDict_Check(value)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "__annotations__ must be set to a dict object");
+        return -1;
+    }
+    Py_XINCREF(value);
+    tmp = op->func_annotations;
+    op->func_annotations = value;
+    Py_XDECREF(tmp);
+    return 0;
+}
+static PyObject *
+__Pyx_CyFunction_get_annotations(__pyx_CyFunctionObject *op) {
+    PyObject* result = op->func_annotations;
+    if (unlikely(!result)) {
+        result = PyDict_New();
+        if (unlikely(!result)) return NULL;
+        op->func_annotations = result;
+    }
+    Py_INCREF(result);
+    return result;
+}
+static PyGetSetDef __pyx_CyFunction_getsets[] = {
+    {(char *) "func_doc", (getter)__Pyx_CyFunction_get_doc, (setter)__Pyx_CyFunction_set_doc, 0, 0},
+    {(char *) "__doc__",  (getter)__Pyx_CyFunction_get_doc, (setter)__Pyx_CyFunction_set_doc, 0, 0},
+    {(char *) "func_name", (getter)__Pyx_CyFunction_get_name, (setter)__Pyx_CyFunction_set_name, 0, 0},
+    {(char *) "__name__", (getter)__Pyx_CyFunction_get_name, (setter)__Pyx_CyFunction_set_name, 0, 0},
+    {(char *) "__qualname__", (getter)__Pyx_CyFunction_get_qualname, (setter)__Pyx_CyFunction_set_qualname, 0, 0},
+    {(char *) "__self__", (getter)__Pyx_CyFunction_get_self, 0, 0, 0},
+    {(char *) "func_dict", (getter)__Pyx_CyFunction_get_dict, (setter)__Pyx_CyFunction_set_dict, 0, 0},
+    {(char *) "__dict__", (getter)__Pyx_CyFunction_get_dict, (setter)__Pyx_CyFunction_set_dict, 0, 0},
+    {(char *) "func_globals", (getter)__Pyx_CyFunction_get_globals, 0, 0, 0},
+    {(char *) "__globals__", (getter)__Pyx_CyFunction_get_globals, 0, 0, 0},
+    {(char *) "func_closure", (getter)__Pyx_CyFunction_get_closure, 0, 0, 0},
+    {(char *) "__closure__", (getter)__Pyx_CyFunction_get_closure, 0, 0, 0},
+    {(char *) "func_code", (getter)__Pyx_CyFunction_get_code, 0, 0, 0},
+    {(char *) "__code__", (getter)__Pyx_CyFunction_get_code, 0, 0, 0},
+    {(char *) "func_defaults", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
+    {(char *) "__defaults__", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
+    {(char *) "__kwdefaults__", (getter)__Pyx_CyFunction_get_kwdefaults, (setter)__Pyx_CyFunction_set_kwdefaults, 0, 0},
+    {(char *) "__annotations__", (getter)__Pyx_CyFunction_get_annotations, (setter)__Pyx_CyFunction_set_annotations, 0, 0},
+    {0, 0, 0, 0, 0}
+};
+static PyMemberDef __pyx_CyFunction_members[] = {
+    {(char *) "__module__", T_OBJECT, offsetof(__pyx_CyFunctionObject, func.m_module), PY_WRITE_RESTRICTED, 0},
+    {0, 0, 0,  0, 0}
+};
+static PyObject *
+__Pyx_CyFunction_reduce(__pyx_CyFunctionObject *m, CYTHON_UNUSED PyObject *args)
+{
+#if PY_MAJOR_VERSION >= 3
+    return PyUnicode_FromString(m->func.m_ml->ml_name);
+#else
+    return PyString_FromString(m->func.m_ml->ml_name);
+#endif
+}
+static PyMethodDef __pyx_CyFunction_methods[] = {
+    {"__reduce__", (PyCFunction)__Pyx_CyFunction_reduce, METH_VARARGS, 0},
+    {0, 0, 0, 0}
+};
+#if PY_VERSION_HEX < 0x030500A0
+#define __Pyx_CyFunction_weakreflist(cyfunc) ((cyfunc)->func_weakreflist)
+#else
+#define __Pyx_CyFunction_weakreflist(cyfunc) ((cyfunc)->func.m_weakreflist)
+#endif
+static PyObject *__Pyx_CyFunction_New(PyTypeObject *type, PyMethodDef *ml, int flags, PyObject* qualname,
+                                      PyObject *closure, PyObject *module, PyObject* globals, PyObject* code) {
+    __pyx_CyFunctionObject *op = PyObject_GC_New(__pyx_CyFunctionObject, type);
+    if (op == NULL)
+        return NULL;
+    op->flags = flags;
+    __Pyx_CyFunction_weakreflist(op) = NULL;
+    op->func.m_ml = ml;
+    op->func.m_self = (PyObject *) op;
+    Py_XINCREF(closure);
+    op->func_closure = closure;
+    Py_XINCREF(module);
+    op->func.m_module = module;
+    op->func_dict = NULL;
+    op->func_name = NULL;
+    Py_INCREF(qualname);
+    op->func_qualname = qualname;
+    op->func_doc = NULL;
+    op->func_classobj = NULL;
+    op->func_globals = globals;
+    Py_INCREF(op->func_globals);
+    Py_XINCREF(code);
+    op->func_code = code;
+    op->defaults_pyobjects = 0;
+    op->defaults = NULL;
+    op->defaults_tuple = NULL;
+    op->defaults_kwdict = NULL;
+    op->defaults_getter = NULL;
+    op->func_annotations = NULL;
+    PyObject_GC_Track(op);
+    return (PyObject *) op;
+}
+static int
+__Pyx_CyFunction_clear(__pyx_CyFunctionObject *m)
+{
+    Py_CLEAR(m->func_closure);
+    Py_CLEAR(m->func.m_module);
+    Py_CLEAR(m->func_dict);
+    Py_CLEAR(m->func_name);
+    Py_CLEAR(m->func_qualname);
+    Py_CLEAR(m->func_doc);
+    Py_CLEAR(m->func_globals);
+    Py_CLEAR(m->func_code);
+    Py_CLEAR(m->func_classobj);
+    Py_CLEAR(m->defaults_tuple);
+    Py_CLEAR(m->defaults_kwdict);
+    Py_CLEAR(m->func_annotations);
+    if (m->defaults) {
+        PyObject **pydefaults = __Pyx_CyFunction_Defaults(PyObject *, m);
+        int i;
+        for (i = 0; i < m->defaults_pyobjects; i++)
+            Py_XDECREF(pydefaults[i]);
+        PyObject_Free(m->defaults);
+        m->defaults = NULL;
+    }
+    return 0;
+}
+static void __Pyx_CyFunction_dealloc(__pyx_CyFunctionObject *m)
+{
+    PyObject_GC_UnTrack(m);
+    if (__Pyx_CyFunction_weakreflist(m) != NULL)
+        PyObject_ClearWeakRefs((PyObject *) m);
+    __Pyx_CyFunction_clear(m);
+    PyObject_GC_Del(m);
+}
+static int __Pyx_CyFunction_traverse(__pyx_CyFunctionObject *m, visitproc visit, void *arg)
+{
+    Py_VISIT(m->func_closure);
+    Py_VISIT(m->func.m_module);
+    Py_VISIT(m->func_dict);
+    Py_VISIT(m->func_name);
+    Py_VISIT(m->func_qualname);
+    Py_VISIT(m->func_doc);
+    Py_VISIT(m->func_globals);
+    Py_VISIT(m->func_code);
+    Py_VISIT(m->func_classobj);
+    Py_VISIT(m->defaults_tuple);
+    Py_VISIT(m->defaults_kwdict);
+    if (m->defaults) {
+        PyObject **pydefaults = __Pyx_CyFunction_Defaults(PyObject *, m);
+        int i;
+        for (i = 0; i < m->defaults_pyobjects; i++)
+            Py_VISIT(pydefaults[i]);
+    }
+    return 0;
+}
+static PyObject *__Pyx_CyFunction_descr_get(PyObject *func, PyObject *obj, PyObject *type)
+{
+    __pyx_CyFunctionObject *m = (__pyx_CyFunctionObject *) func;
+    if (m->flags & __Pyx_CYFUNCTION_STATICMETHOD) {
+        Py_INCREF(func);
+        return func;
+    }
+    if (m->flags & __Pyx_CYFUNCTION_CLASSMETHOD) {
+        if (type == NULL)
+            type = (PyObject *)(Py_TYPE(obj));
+        return __Pyx_PyMethod_New(func, type, (PyObject *)(Py_TYPE(type)));
+    }
+    if (obj == Py_None)
+        obj = NULL;
+    return __Pyx_PyMethod_New(func, obj, type);
+}
+static PyObject*
+__Pyx_CyFunction_repr(__pyx_CyFunctionObject *op)
+{
+#if PY_MAJOR_VERSION >= 3
+    return PyUnicode_FromFormat("<cyfunction %U at %p>",
+                                op->func_qualname, (void *)op);
+#else
+    return PyString_FromFormat("<cyfunction %s at %p>",
+                               PyString_AsString(op->func_qualname), (void *)op);
+#endif
+}
+#if CYTHON_COMPILING_IN_PYPY
+static PyObject * __Pyx_CyFunction_Call(PyObject *func, PyObject *arg, PyObject *kw) {
+    PyCFunctionObject* f = (PyCFunctionObject*)func;
+    PyCFunction meth = f->m_ml->ml_meth;
+    PyObject *self = f->m_self;
+    Py_ssize_t size;
+    switch (f->m_ml->ml_flags & (METH_VARARGS | METH_KEYWORDS | METH_NOARGS | METH_O)) {
+    case METH_VARARGS:
+        if (likely(kw == NULL || PyDict_Size(kw) == 0))
+            return (*meth)(self, arg);
+        break;
+    case METH_VARARGS | METH_KEYWORDS:
+        return (*(PyCFunctionWithKeywords)meth)(self, arg, kw);
+    case METH_NOARGS:
+        if (likely(kw == NULL || PyDict_Size(kw) == 0)) {
+            size = PyTuple_GET_SIZE(arg);
+            if (likely(size == 0))
+                return (*meth)(self, NULL);
+            PyErr_Format(PyExc_TypeError,
+                "%.200s() takes no arguments (%" CYTHON_FORMAT_SSIZE_T "d given)",
+                f->m_ml->ml_name, size);
+            return NULL;
+        }
+        break;
+    case METH_O:
+        if (likely(kw == NULL || PyDict_Size(kw) == 0)) {
+            size = PyTuple_GET_SIZE(arg);
+            if (likely(size == 1)) {
+                PyObject *result, *arg0 = PySequence_ITEM(arg, 0);
+                if (unlikely(!arg0)) return NULL;
+                result = (*meth)(self, arg0);
+                Py_DECREF(arg0);
+                return result;
+            }
+            PyErr_Format(PyExc_TypeError,
+                "%.200s() takes exactly one argument (%" CYTHON_FORMAT_SSIZE_T "d given)",
+                f->m_ml->ml_name, size);
+            return NULL;
+        }
+        break;
+    default:
+        PyErr_SetString(PyExc_SystemError, "Bad call flags in "
+                        "__Pyx_CyFunction_Call. METH_OLDARGS is no "
+                        "longer supported!");
+        return NULL;
+    }
+    PyErr_Format(PyExc_TypeError, "%.200s() takes no keyword arguments",
+                 f->m_ml->ml_name);
+    return NULL;
+}
+#else
+static PyObject * __Pyx_CyFunction_Call(PyObject *func, PyObject *arg, PyObject *kw) {
+	return PyCFunction_Call(func, arg, kw);
+}
+#endif
+static PyTypeObject __pyx_CyFunctionType_type = {
+    PyVarObject_HEAD_INIT(0, 0)
+    "cython_function_or_method",
+    sizeof(__pyx_CyFunctionObject),
+    0,
+    (destructor) __Pyx_CyFunction_dealloc,
+    0,
+    0,
+    0,
+#if PY_MAJOR_VERSION < 3
+    0,
+#else
+    0,
+#endif
+    (reprfunc) __Pyx_CyFunction_repr,
+    0,
+    0,
+    0,
+    0,
+    __Pyx_CyFunction_Call,
+    0,
+    0,
+    0,
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    0,
+    (traverseproc) __Pyx_CyFunction_traverse,
+    (inquiry) __Pyx_CyFunction_clear,
+    0,
+#if PY_VERSION_HEX < 0x030500A0
+    offsetof(__pyx_CyFunctionObject, func_weakreflist),
+#else
+    offsetof(PyCFunctionObject, m_weakreflist),
+#endif
+    0,
+    0,
+    __pyx_CyFunction_methods,
+    __pyx_CyFunction_members,
+    __pyx_CyFunction_getsets,
+    0,
+    0,
+    __Pyx_CyFunction_descr_get,
+    0,
+    offsetof(__pyx_CyFunctionObject, func_dict),
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+#if PY_VERSION_HEX >= 0x030400a1
+    0,
+#endif
+};
+static int __pyx_CyFunction_init(void) {
+#if !CYTHON_COMPILING_IN_PYPY
+    __pyx_CyFunctionType_type.tp_call = PyCFunction_Call;
+#endif
+    __pyx_CyFunctionType = __Pyx_FetchCommonType(&__pyx_CyFunctionType_type);
+    if (__pyx_CyFunctionType == NULL) {
+        return -1;
+    }
+    return 0;
+}
+static CYTHON_INLINE void *__Pyx_CyFunction_InitDefaults(PyObject *func, size_t size, int pyobjects) {
+    __pyx_CyFunctionObject *m = (__pyx_CyFunctionObject *) func;
+    m->defaults = PyObject_Malloc(size);
+    if (!m->defaults)
+        return PyErr_NoMemory();
+    memset(m->defaults, 0, size);
+    m->defaults_pyobjects = pyobjects;
+    return m->defaults;
+}
+static CYTHON_INLINE void __Pyx_CyFunction_SetDefaultsTuple(PyObject *func, PyObject *tuple) {
+    __pyx_CyFunctionObject *m = (__pyx_CyFunctionObject *) func;
+    m->defaults_tuple = tuple;
+    Py_INCREF(tuple);
+}
+static CYTHON_INLINE void __Pyx_CyFunction_SetDefaultsKwDict(PyObject *func, PyObject *dict) {
+    __pyx_CyFunctionObject *m = (__pyx_CyFunctionObject *) func;
+    m->defaults_kwdict = dict;
+    Py_INCREF(dict);
+}
+static CYTHON_INLINE void __Pyx_CyFunction_SetAnnotationsDict(PyObject *func, PyObject *dict) {
+    __pyx_CyFunctionObject *m = (__pyx_CyFunctionObject *) func;
+    m->func_annotations = dict;
+    Py_INCREF(dict);
+}
+
+/* CalculateMetaclass */
+            static PyObject *__Pyx_CalculateMetaclass(PyTypeObject *metaclass, PyObject *bases) {
+    Py_ssize_t i, nbases = PyTuple_GET_SIZE(bases);
+    for (i=0; i < nbases; i++) {
+        PyTypeObject *tmptype;
+        PyObject *tmp = PyTuple_GET_ITEM(bases, i);
+        tmptype = Py_TYPE(tmp);
+#if PY_MAJOR_VERSION < 3
+        if (tmptype == &PyClass_Type)
+            continue;
+#endif
+        if (!metaclass) {
+            metaclass = tmptype;
+            continue;
+        }
+        if (PyType_IsSubtype(metaclass, tmptype))
+            continue;
+        if (PyType_IsSubtype(tmptype, metaclass)) {
+            metaclass = tmptype;
+            continue;
+        }
+        PyErr_SetString(PyExc_TypeError,
+                        "metaclass conflict: "
+                        "the metaclass of a derived class "
+                        "must be a (non-strict) subclass "
+                        "of the metaclasses of all its bases");
+        return NULL;
+    }
+    if (!metaclass) {
+#if PY_MAJOR_VERSION < 3
+        metaclass = &PyClass_Type;
+#else
+        metaclass = &PyType_Type;
+#endif
+    }
+    Py_INCREF((PyObject*) metaclass);
+    return (PyObject*) metaclass;
+}
+
+/* Py3ClassCreate */
+            static PyObject *__Pyx_Py3MetaclassPrepare(PyObject *metaclass, PyObject *bases, PyObject *name,
+                                           PyObject *qualname, PyObject *mkw, PyObject *modname, PyObject *doc) {
+    PyObject *ns;
+    if (metaclass) {
+        PyObject *prep = __Pyx_PyObject_GetAttrStr(metaclass, __pyx_n_s_prepare);
+        if (prep) {
+            PyObject *pargs = PyTuple_Pack(2, name, bases);
+            if (unlikely(!pargs)) {
+                Py_DECREF(prep);
+                return NULL;
+            }
+            ns = PyObject_Call(prep, pargs, mkw);
+            Py_DECREF(prep);
+            Py_DECREF(pargs);
+        } else {
+            if (unlikely(!PyErr_ExceptionMatches(PyExc_AttributeError)))
+                return NULL;
+            PyErr_Clear();
+            ns = PyDict_New();
+        }
+    } else {
+        ns = PyDict_New();
+    }
+    if (unlikely(!ns))
+        return NULL;
+    if (unlikely(PyObject_SetItem(ns, __pyx_n_s_module, modname) < 0)) goto bad;
+    if (unlikely(PyObject_SetItem(ns, __pyx_n_s_qualname, qualname) < 0)) goto bad;
+    if (unlikely(doc && PyObject_SetItem(ns, __pyx_n_s_doc, doc) < 0)) goto bad;
+    return ns;
+bad:
+    Py_DECREF(ns);
+    return NULL;
+}
+static PyObject *__Pyx_Py3ClassCreate(PyObject *metaclass, PyObject *name, PyObject *bases,
+                                      PyObject *dict, PyObject *mkw,
+                                      int calculate_metaclass, int allow_py2_metaclass) {
+    PyObject *result, *margs;
+    PyObject *owned_metaclass = NULL;
+    if (allow_py2_metaclass) {
+        owned_metaclass = PyObject_GetItem(dict, __pyx_n_s_metaclass);
+        if (owned_metaclass) {
+            metaclass = owned_metaclass;
+        } else if (likely(PyErr_ExceptionMatches(PyExc_KeyError))) {
+            PyErr_Clear();
+        } else {
+            return NULL;
+        }
+    }
+    if (calculate_metaclass && (!metaclass || PyType_Check(metaclass))) {
+        metaclass = __Pyx_CalculateMetaclass((PyTypeObject*) metaclass, bases);
+        Py_XDECREF(owned_metaclass);
+        if (unlikely(!metaclass))
+            return NULL;
+        owned_metaclass = metaclass;
+    }
+    margs = PyTuple_Pack(3, name, bases, dict);
+    if (unlikely(!margs)) {
+        result = NULL;
+    } else {
+        result = PyObject_Call(metaclass, margs, mkw);
+        Py_DECREF(margs);
+    }
+    Py_XDECREF(owned_metaclass);
+    return result;
+}
+
 /* CodeObjectCache */
-    static int __pyx_bisect_code_objects(__Pyx_CodeObjectCacheEntry* entries, int count, int code_line) {
+            static int __pyx_bisect_code_objects(__Pyx_CodeObjectCacheEntry* entries, int count, int code_line) {
     int start = 0, mid = 0, end = count - 1;
     if (end >= 0 && code_line > entries[end].code_line) {
         return count;
@@ -2396,7 +4097,7 @@ static void __pyx_insert_code_object(int code_line, PyCodeObject* code_object) {
 }
 
 /* AddTraceback */
-    #include "compile.h"
+            #include "compile.h"
 #include "frameobject.h"
 #include "traceback.h"
 static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
@@ -2477,7 +4178,7 @@ bad:
 }
 
 /* CIntToPy */
-    static CYTHON_INLINE PyObject* __Pyx_PyInt_From_HASH_FUNCTION(HASH_FUNCTION value) {
+            static CYTHON_INLINE PyObject* __Pyx_PyInt_From_HASH_FUNCTION(HASH_FUNCTION value) {
     const HASH_FUNCTION neg_one = (HASH_FUNCTION) -1, const_zero = (HASH_FUNCTION) 0;
     const int is_unsigned = neg_one > const_zero;
     if (is_unsigned) {
@@ -2504,7 +4205,7 @@ bad:
 }
 
 /* CIntFromPyVerify */
-    #define __PYX_VERIFY_RETURN_INT(target_type, func_type, func_value)\
+            #define __PYX_VERIFY_RETURN_INT(target_type, func_type, func_value)\
     __PYX__VERIFY_RETURN_INT(target_type, func_type, func_value, 0)
 #define __PYX_VERIFY_RETURN_INT_EXC(target_type, func_type, func_value)\
     __PYX__VERIFY_RETURN_INT(target_type, func_type, func_value, 1)
@@ -2526,7 +4227,7 @@ bad:
     }
 
 /* CIntToPy */
-    static CYTHON_INLINE PyObject* __Pyx_PyInt_From_unsigned_int(unsigned int value) {
+            static CYTHON_INLINE PyObject* __Pyx_PyInt_From_unsigned_int(unsigned int value) {
     const unsigned int neg_one = (unsigned int) -1, const_zero = (unsigned int) 0;
     const int is_unsigned = neg_one > const_zero;
     if (is_unsigned) {
@@ -2553,7 +4254,7 @@ bad:
 }
 
 /* CIntFromPy */
-    static CYTHON_INLINE HASH_FUNCTION __Pyx_PyInt_As_HASH_FUNCTION(PyObject *x) {
+            static CYTHON_INLINE HASH_FUNCTION __Pyx_PyInt_As_HASH_FUNCTION(PyObject *x) {
     const HASH_FUNCTION neg_one = (HASH_FUNCTION) -1, const_zero = (HASH_FUNCTION) 0;
     const int is_unsigned = neg_one > const_zero;
 #if PY_MAJOR_VERSION < 3
@@ -2738,7 +4439,7 @@ raise_neg_overflow:
 }
 
 /* CIntFromPy */
-    static CYTHON_INLINE unsigned int __Pyx_PyInt_As_unsigned_int(PyObject *x) {
+            static CYTHON_INLINE unsigned int __Pyx_PyInt_As_unsigned_int(PyObject *x) {
     const unsigned int neg_one = (unsigned int) -1, const_zero = (unsigned int) 0;
     const int is_unsigned = neg_one > const_zero;
 #if PY_MAJOR_VERSION < 3
@@ -2923,7 +4624,7 @@ raise_neg_overflow:
 }
 
 /* CIntFromPy */
-    static CYTHON_INLINE size_t __Pyx_PyInt_As_size_t(PyObject *x) {
+            static CYTHON_INLINE size_t __Pyx_PyInt_As_size_t(PyObject *x) {
     const size_t neg_one = (size_t) -1, const_zero = (size_t) 0;
     const int is_unsigned = neg_one > const_zero;
 #if PY_MAJOR_VERSION < 3
@@ -3108,7 +4809,7 @@ raise_neg_overflow:
 }
 
 /* CIntToPy */
-    static CYTHON_INLINE PyObject* __Pyx_PyInt_From_long(long value) {
+            static CYTHON_INLINE PyObject* __Pyx_PyInt_From_long(long value) {
     const long neg_one = (long) -1, const_zero = (long) 0;
     const int is_unsigned = neg_one > const_zero;
     if (is_unsigned) {
@@ -3135,7 +4836,7 @@ raise_neg_overflow:
 }
 
 /* CIntFromPy */
-    static CYTHON_INLINE long __Pyx_PyInt_As_long(PyObject *x) {
+            static CYTHON_INLINE long __Pyx_PyInt_As_long(PyObject *x) {
     const long neg_one = (long) -1, const_zero = (long) 0;
     const int is_unsigned = neg_one > const_zero;
 #if PY_MAJOR_VERSION < 3
@@ -3320,7 +5021,7 @@ raise_neg_overflow:
 }
 
 /* CIntFromPy */
-    static CYTHON_INLINE int __Pyx_PyInt_As_int(PyObject *x) {
+            static CYTHON_INLINE int __Pyx_PyInt_As_int(PyObject *x) {
     const int neg_one = (int) -1, const_zero = (int) 0;
     const int is_unsigned = neg_one > const_zero;
 #if PY_MAJOR_VERSION < 3
@@ -3505,7 +5206,7 @@ raise_neg_overflow:
 }
 
 /* CheckBinaryVersion */
-    static int __Pyx_check_binary_version(void) {
+            static int __Pyx_check_binary_version(void) {
     char ctversion[4], rtversion[4];
     PyOS_snprintf(ctversion, 4, "%d.%d", PY_MAJOR_VERSION, PY_MINOR_VERSION);
     PyOS_snprintf(rtversion, 4, "%s", Py_GetVersion());
@@ -3521,7 +5222,7 @@ raise_neg_overflow:
 }
 
 /* InitStrings */
-    static int __Pyx_InitStrings(__Pyx_StringTabEntry *t) {
+            static int __Pyx_InitStrings(__Pyx_StringTabEntry *t) {
     while (t->p) {
         #if PY_MAJOR_VERSION < 3
         if (t->is_unicode) {

--- a/hash_ring/hash_ring.pyx
+++ b/hash_ring/hash_ring.pyx
@@ -10,7 +10,7 @@ cdef extern from 'hash_ring.h':
     cdef HASH_FUNCTION _HASH_FUNCTION_MD5 'HASH_FUNCTION_MD5'
 
     ctypedef struct hash_ring_t:
-        pass
+        unsigned int num_items 'numItems'
 
     ctypedef struct hash_ring_node_t:
         unsigned char *name
@@ -19,15 +19,19 @@ cdef extern from 'hash_ring.h':
 
     hash_ring_t *hash_ring_create(HASH_FUNCTION hash_fn)
     void hash_ring_free(hash_ring_t *ring)
-    int hash_ring_add_node(hash_ring_t *ring, unsigned char *name, unsigned int name_len, unsigned int num_replicas)
+    int hash_ring_add_node(hash_ring_t *ring, unsigned char *name, unsigned int name_len, unsigned int num_replicas,
+                           int do_sort)
+    hash_ring_node_t*hash_ring_get_node(hash_ring_t *ring, unsigned char *name, unsigned int name_len)
     hash_ring_node_t *hash_ring_find_node(hash_ring_t *ring, unsigned char *key, unsigned int key_len)
-    int hash_ring_find_nodes(hash_ring_t *ring, unsigned char *key, unsigned int key_len, hash_ring_node_t *nodes[], unsigned int num)
+    int hash_ring_find_nodes(hash_ring_t *ring, unsigned char *key, unsigned int key_len, hash_ring_node_t *nodes[],
+                             unsigned int num)
     int hash_ring_remove_node(hash_ring_t *ring, unsigned char *name, unsigned int name_len)
     void hash_ring_print(hash_ring_t *ring)
+    int hash_ring_ensure_items_size(hash_ring_t *ring, size_t target_items_size)
+    int hash_ring_sort(hash_ring_t *ring)
 
 HASH_FUNCTION_SHA1 = _HASH_FUNCTION_SHA1
 HASH_FUNCTION_MD5 = _HASH_FUNCTION_MD5
-
 cdef class HashRing:
     cdef hash_ring_t *_ring
     cdef unsigned int _default_num_replicas
@@ -43,7 +47,31 @@ cdef class HashRing:
         if num_replicas is None:
             num_replicas = self._default_num_replicas
 
-        return hash_ring_add_node(self._ring, name, len(name), num_replicas) == HASH_RING_OK
+        return hash_ring_add_node(self._ring, name, len(name), num_replicas, 1) == HASH_RING_OK
+
+    def add_nodes(self, nodes):
+        if not nodes:
+            return
+
+        # Cannot add nodes if the ring already has nodes.
+        if self.get_num_items() > 0:
+            return False
+
+        cdef size_t items_size_target = 0
+        for node in nodes:
+            if node.num_replicas is None:
+                node.num_replicas = self._default_num_replicas
+
+            items_size_target += node.num_replicas
+
+        if hash_ring_ensure_items_size(self._ring, items_size_target) != HASH_RING_OK:
+            return False
+
+        for node in nodes:
+            if hash_ring_add_node(self._ring, node.name, len(node.name), node.num_replicas, 0) != HASH_RING_OK:
+                return False
+
+        return hash_ring_sort(self._ring) == HASH_RING_OK
 
     def remove_node(self, name):
         return hash_ring_remove_node(self._ring, name, len(name)) == HASH_RING_OK
@@ -54,18 +82,38 @@ cdef class HashRing:
     def find_node(self, key):
         if not isinstance(key, bytes):
             key = bytes(key)
+
         node = hash_ring_find_node(self._ring, key, len(key))
+
         if node:
             return node.name[:node.name_len]
 
     def find_nodes(self, key, num=1):
         if not isinstance(key, bytes):
             key = bytes(key)
-        cdef hash_ring_node_t **nodes = <hash_ring_node_t **>malloc(sizeof(hash_ring_node_t *) * num)
+
+        cdef hash_ring_node_t ** nodes = <hash_ring_node_t **> malloc(sizeof(hash_ring_node_t *) * num)
         if not nodes:
             raise MemoryError()
+
         try:
             n = hash_ring_find_nodes(self._ring, key, len(key), nodes, num)
             return [node.name[:node.name_len] for node in nodes[:n]] if n > -1 else []
+
         finally:
             free(nodes)
+
+    def get_num_items(self):
+        return self._ring.num_items
+
+    def get_node(self, node_name):
+        node = hash_ring_get_node(self._ring, node_name, len(node_name))
+        if not node:
+            return None
+
+        return HashRingNode(name=node.name[:node.name_len], num_replicas=node.num_replicas)
+
+class HashRingNode:
+    def __init__(self, name, num_replicas):
+        self.name = name
+        self.num_replicas = num_replicas

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,6 @@ setup(
     zip_safe=False,
     cmdclass=cmdclass,
     ext_modules=[ext],
+    tests_require=['pytest'],
+    setup_requires=['pytest-runner']
 )

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     cmdclass=cmdclass,
     ext_modules=[ext],
     tests_require=['pytest'],
-    setup_requires=['pytest-runner']
+    setup_requires=['pytest-runner', 'pytest-benchmark']
 )

--- a/test/test_hash_ring.py
+++ b/test/test_hash_ring.py
@@ -63,31 +63,3 @@ def test_hash_ring_stress_test():
         assert ring.get_num_items() == total_items
 
     assert total_items == 0
-
-
-def ring_fast(num_nodes):
-    r = HashRing()
-    nodes = []
-    for i in xrange(num_nodes):
-        nodes.append(HashRingNode('test-%i' % i, num_replicas=512))
-
-    r.add_nodes(nodes)
-
-
-def ring_slow(num_nodes):
-    r = HashRing()
-    nodes = []
-    for i in xrange(num_nodes):
-        r.add_node('test-%i' % i, num_replicas=512)
-
-    r.add_nodes(nodes)
-
-
-@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
-def test_ring_add_nodes_slow(benchmark, num_nodes):
-    benchmark(ring_slow, num_nodes)
-
-
-@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
-def test_ring_add_nodes_fast(benchmark, num_nodes):
-    benchmark(ring_fast, num_nodes)

--- a/test/test_hash_ring.py
+++ b/test/test_hash_ring.py
@@ -1,7 +1,8 @@
+import pytest
+
 import random
 
-from hash_ring import HashRing
-from hash_ring.hash_ring import HashRingNode
+from hash_ring import HashRing, HashRingNode
 
 
 def test_hash_ring_basic_flow():
@@ -64,22 +65,29 @@ def test_hash_ring_stress_test():
     assert total_items == 0
 
 
-from hash_ring import HashRing, HashRingNode
-
-
-def ring_fast():
+def ring_fast(num_nodes):
     r = HashRing()
     nodes = []
-    for i in xrange(100):
+    for i in xrange(num_nodes):
         nodes.append(HashRingNode('test-%i' % i, num_replicas=512))
 
     r.add_nodes(nodes)
 
 
-def ring_slow():
+def ring_slow(num_nodes):
     r = HashRing()
     nodes = []
-    for i in xrange(100):
+    for i in xrange(num_nodes):
         r.add_node('test-%i' % i, num_replicas=512)
 
     r.add_nodes(nodes)
+
+
+@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
+def test_ring_add_nodes_slow(benchmark, num_nodes):
+    benchmark(ring_slow, num_nodes)
+
+
+@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
+def test_ring_add_nodes_fast(benchmark, num_nodes):
+    benchmark(ring_fast, num_nodes)

--- a/test/test_hash_ring.py
+++ b/test/test_hash_ring.py
@@ -1,0 +1,85 @@
+import random
+
+from hash_ring import HashRing
+from hash_ring.hash_ring import HashRingNode
+
+
+def test_hash_ring_basic_flow():
+    ring = HashRing()
+    # A ring with no node can't find any nodes.
+    assert ring.find_node(1) is None
+
+    # Adding a node should find the node.
+    assert ring.add_node('test')
+    assert ring.find_node(1) == 'test'
+
+    # Removing it should work.
+    assert ring.remove_node('test')
+    assert ring.find_node(1) is None
+
+
+def test_hash_ring_add():
+    ring = HashRing()
+
+    assert ring.get_num_items() == 0
+    assert ring.get_node('test') is None
+    assert ring.add_node('test', num_replicas=128)
+    node = ring.get_node('test')
+    assert node.name == 'test'
+    assert node.num_replicas == 128
+
+    assert ring.get_num_items() == 128
+    assert ring.remove_node('test')
+    assert ring.get_num_items() == 0
+
+    assert ring.add_node('test', num_replicas=64)
+    node = ring.get_node('test')
+    assert node.name == 'test'
+    assert node.num_replicas == 64
+    assert ring.get_num_items() == 64
+
+
+def test_hash_ring_stress_test():
+    replica_sizes = [2 ** i for i in xrange(10)]
+
+    ring = HashRing()
+    config = []
+    for i in xrange(500):
+        name = 'test-%i' % i
+        num_replicas = replica_sizes[hash(name) % len(replica_sizes)]
+        config.append((name, num_replicas))
+
+    total_items = 0
+    for name, num_replicas in config:
+        total_items += num_replicas
+        assert ring.add_node(name, num_replicas=num_replicas)
+        assert ring.get_num_items() == total_items
+
+    random.shuffle(config)
+    for name, num_replicas in config:
+        assert ring.remove_node(name)
+        total_items -= num_replicas
+        assert ring.get_num_items() == total_items
+
+    assert total_items == 0
+
+
+from hash_ring import HashRing, HashRingNode
+
+
+def ring_fast():
+    r = HashRing()
+    nodes = []
+    for i in xrange(100):
+        nodes.append(HashRingNode('test-%i' % i, num_replicas=512))
+
+    r.add_nodes(nodes)
+
+
+def ring_slow():
+    r = HashRing()
+    nodes = []
+    for i in xrange(100):
+        r.add_node('test-%i' % i, num_replicas=512)
+
+    r.add_nodes(nodes)

--- a/test/test_hash_ring.py
+++ b/test/test_hash_ring.py
@@ -1,6 +1,7 @@
 import pytest
 
 import random
+from collections import Counter
 
 from hash_ring import HashRing, HashRingNode
 
@@ -45,7 +46,7 @@ def test_hash_ring_stress_test():
 
     ring = HashRing()
     config = []
-    for i in xrange(500):
+    for i in xrange(20):
         name = 'test-%i' % i
         num_replicas = replica_sizes[hash(name) % len(replica_sizes)]
         config.append((name, num_replicas))
@@ -63,3 +64,63 @@ def test_hash_ring_stress_test():
         assert ring.get_num_items() == total_items
 
     assert total_items == 0
+
+
+def test_hash_ring_stress_fast():
+    replica_sizes = [2 ** i for i in xrange(10)]
+
+    ring = HashRing()
+    nodes = []
+    total_items = 0
+    for i in xrange(20):
+        name = 'test-%i' % i
+        num_replicas = replica_sizes[hash(name) % len(replica_sizes)]
+        nodes.append(HashRingNode(name=name, num_replicas=num_replicas))
+        total_items += num_replicas
+
+    ring.add_nodes(nodes)
+    assert ring.get_num_items() == total_items
+    random.shuffle(nodes)
+    for node in nodes:
+        assert ring.remove_node(node.name)
+        total_items -= node.num_replicas
+        assert ring.get_num_items() == total_items
+
+    assert total_items == 0
+
+
+def gen_hash_ring_fast(nodes):
+    ring = HashRing()
+    ring.add_nodes([n[0] for n in nodes])
+    return ring
+
+
+def gen_hash_ring_slow(nodes):
+    ring = HashRing()
+    for node, _ in nodes:
+        ring.add_node(node.name, node.num_replicas)
+    return ring
+
+
+N = lambda name, c, num_replicas=512: (HashRingNode(name=name, num_replicas=num_replicas), c)
+
+
+@pytest.mark.parametrize('ring_generator', [gen_hash_ring_fast, gen_hash_ring_slow])
+@pytest.mark.parametrize('nodes', [
+    (N('test-1', 32992), N('test-2', 33680), N('test-3', 33328)),
+    (N('test-1', 10557, num_replicas=128), N('test-2', 44721), N('test-3', 44722)),
+    (N('test-1', 49910, num_replicas=1024), N('test-2', 25683), N('test-3', 24407)),
+    # These test wildly imbalanced ring configurations.
+    (N('test-1', 21026, num_replicas=1), N('test-2', 48816, num_replicas=1), N('test-3', 30158, num_replicas=1)),
+    (N('test-1', 99635, num_replicas=1024), N('test-2', 271, num_replicas=1), N('test-3', 94, num_replicas=1)),
+])
+def test_hash_ring_distributions(ring_generator, nodes):
+    ring = ring_generator(nodes)
+
+    c = Counter()
+    for i in xrange(100000):
+        node_name = ring.find_node(i)
+        c[node_name] += 1
+
+    for node, count in nodes:
+        assert c[node.name] == count, 'Expected %i nodes for %s, got %s' % (count, node.name, c[node.name])

--- a/test/test_hash_ring.py
+++ b/test/test_hash_ring.py
@@ -102,7 +102,7 @@ def gen_hash_ring_slow(nodes):
     return ring
 
 
-N = lambda name, c, num_replicas=512: (HashRingNode(name=name, num_replicas=num_replicas), c)
+N = lambda name, count, num_replicas=512: (HashRingNode(name=name, num_replicas=num_replicas), count)
 
 
 @pytest.mark.parametrize('ring_generator', [gen_hash_ring_fast, gen_hash_ring_slow])

--- a/test/test_hash_ring_benchmarks.py
+++ b/test/test_hash_ring_benchmarks.py
@@ -5,6 +5,7 @@ from hash_ring import HashRingNode, HashRing
 pytestmark = [pytest.mark.benchmark]
 
 
+@pytest.mark.benchmark(group='add_nodes')
 @pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
 def test_ring_add_nodes_slow(benchmark, num_nodes):
     def ring_slow():
@@ -18,6 +19,7 @@ def test_ring_add_nodes_slow(benchmark, num_nodes):
     benchmark(ring_slow)
 
 
+@pytest.mark.benchmark(group='add_nodes')
 @pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
 def test_ring_add_nodes_fast(benchmark, num_nodes):
     def ring_fast():
@@ -31,6 +33,7 @@ def test_ring_add_nodes_fast(benchmark, num_nodes):
     benchmark(ring_fast)
 
 
+@pytest.mark.benchmark(group='find_node')
 @pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
 def test_ring_find_node(benchmark, num_nodes):
     r = HashRing()
@@ -46,6 +49,7 @@ def test_ring_find_node(benchmark, num_nodes):
     assert benchmark(ring_lookup) == r.find_node('hello')
 
 
+@pytest.mark.benchmark(group='find_nodes')
 @pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
 def test_ring_find_nodes(benchmark, num_nodes):
     r = HashRing()

--- a/test/test_hash_ring_benchmarks.py
+++ b/test/test_hash_ring_benchmarks.py
@@ -1,0 +1,61 @@
+import pytest
+
+from hash_ring import HashRingNode, HashRing
+
+pytestmark = [pytest.mark.benchmark]
+
+
+@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
+def test_ring_add_nodes_slow(benchmark, num_nodes):
+    def ring_slow():
+        r = HashRing()
+        nodes = []
+        for i in xrange(num_nodes):
+            r.add_node('test-%i' % i, num_replicas=512)
+
+        r.add_nodes(nodes)
+
+    benchmark(ring_slow)
+
+
+@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
+def test_ring_add_nodes_fast(benchmark, num_nodes):
+    def ring_fast():
+        r = HashRing()
+        nodes = []
+        for i in xrange(num_nodes):
+            nodes.append(HashRingNode('test-%i' % i, num_replicas=512))
+
+        r.add_nodes(nodes)
+
+    benchmark(ring_fast)
+
+
+@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
+def test_ring_find_node(benchmark, num_nodes):
+    r = HashRing()
+    nodes = []
+    for i in xrange(num_nodes):
+        r.add_node('test-%i' % i, num_replicas=512)
+
+    r.add_nodes(nodes)
+
+    def ring_lookup():
+        return r.find_node('hello')
+
+    assert benchmark(ring_lookup) == r.find_node('hello')
+
+
+@pytest.mark.parametrize('num_nodes', [5, 10, 25, 50, 100])
+def test_ring_find_nodes(benchmark, num_nodes):
+    r = HashRing()
+    nodes = []
+    for i in xrange(num_nodes):
+        r.add_node('test-%i' % i, num_replicas=512)
+
+    r.add_nodes(nodes)
+
+    def ring_lookup():
+        return r.find_nodes('hello', 3)
+
+    assert benchmark(ring_lookup) == r.find_nodes('hello', 3)


### PR DESCRIPTION
Rebuilding the ring each time the ring changes turns out to be a really slow operation. This hopes to address this by creating an `add_nodes` operation that can be performed on an empty ring that is faster than individually calling `add_node` for each node in the ring. So far, the benchmarks are promising, the `add_nodes` operation taking 2% the wall time of calling `add_node` individually for larger ring sizes. Right now, this operation will run in the event loop of our API servers, so making it go faster is a good way to reduce the impact of re-building the ring.

Here is a result of the benches of adding nodes in the slow (add_node) vs fast (add_nodes) path, for 512 replicas per node:

![image](https://user-images.githubusercontent.com/5489149/35601571-a3f5e65c-05e8-11e8-8b31-caceb908f56d.png)


TODO:
 - [x] add `HashRing.add_nodes(nodes)` method.
 - [x] add `HashRing.get_num_items()` method for debugging.
 - [x] add `HashRing.get_node(node_name)` method for debugging. 
 - [x] add `hash_ring_sort` method that will sort the ring items array after we're done adding stuff to 
it.
 - [x] add `hash_ring_ensure_items_size` which will allow us to pre-allocate the `items` array, so we do not need to needlessly realloc it to grow, if we can compute the target size before hand.
 - [x] mod `hash_ring_add_node` to take a `doSort` param, to defer sorting of the items array. 
 - [x] formalize benchmarks with pytest-bench
 - [x] test coverage around this.